### PR TITLE
Allow Base path and API paths to be set

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": "22.x"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "engines": {
-    "node": "22.x"
-  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
@@ -30,6 +27,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",
+    "@types/node": "22.14.1",
     "@types/react": "18.2.42",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react-swc": "^3.5.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,9 +7,10 @@ import {
 import { Map } from './components/pages/';
 // import { Home, Map } from './components/pages/';
 import ErrorPage from './components/pages/Error';
+import { BASE_ROUTE } from './components/helpers/RouteHelper.ts';
 // import { ToS } from './components/pages/ToS';
 
-const router = createBrowserRouter(
+const router = createBrowserRouter([
   createRoutesFromElements(
     <>
       <Route path="/" element={<Map />} errorElement={<ErrorPage />} />
@@ -18,7 +19,7 @@ const router = createBrowserRouter(
       {/* <Route path="/map" element={<Map />} /> */}
       {/* <Route path="/tos" element={<ToS />} /> */}
     </>
-  )
+  )], {basename: BASE_ROUTE}
 );
 
 export default function App() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import ErrorPage from './components/pages/Error';
 import { BASE_ROUTE } from './components/helpers/RouteHelper.ts';
 // import { ToS } from './components/pages/ToS';
 
-const router = createBrowserRouter([
+const router = createBrowserRouter(
   createRoutesFromElements(
     <>
       <Route path="/" element={<Map />} errorElement={<ErrorPage />} />
@@ -19,7 +19,7 @@ const router = createBrowserRouter([
       {/* <Route path="/map" element={<Map />} /> */}
       {/* <Route path="/tos" element={<ToS />} /> */}
     </>
-  )], {basename: BASE_ROUTE}
+  ), {basename: BASE_ROUTE}
 );
 
 export default function App() {

--- a/src/components/helpers/ApiHelper.ts
+++ b/src/components/helpers/ApiHelper.ts
@@ -1,0 +1,6 @@
+
+let baseUrl = import.meta.env.VITE_API_URL as string;
+
+const API_BASE_URL = baseUrl? baseUrl : 'https://roguewar.org';
+
+export { API_BASE_URL };

--- a/src/components/helpers/ApiHelper.ts
+++ b/src/components/helpers/ApiHelper.ts
@@ -1,5 +1,5 @@
 
-let baseUrl = import.meta.env.VITE_API_URL as string;
+const baseUrl:string = import.meta.env.VITE_API_URL;
 
 const API_BASE_URL = baseUrl? baseUrl : 'https://roguewar.org';
 

--- a/src/components/helpers/RouteHelper.ts
+++ b/src/components/helpers/RouteHelper.ts
@@ -1,4 +1,4 @@
-let baseRoute = import.meta.env.VITE_BASE_URL as string;
+const baseRoute: string = import.meta.env.VITE_BASE_URL;
 
 const BASE_ROUTE = baseRoute? baseRoute : '/';
 

--- a/src/components/helpers/RouteHelper.ts
+++ b/src/components/helpers/RouteHelper.ts
@@ -1,0 +1,5 @@
+let baseRoute = import.meta.env.VITE_BASE_URL as string;
+
+const BASE_ROUTE = baseRoute? baseRoute : '/';
+
+export { BASE_ROUTE };

--- a/src/components/hooks/useWarmapAPI.ts
+++ b/src/components/hooks/useWarmapAPI.ts
@@ -1,20 +1,17 @@
 import { useState } from 'react';
 import { FactionDataType, StarSystemType } from './types';
+import { API_BASE_URL } from '../helpers/ApiHelper.ts';
 
 const useWarmapAPI = () => {
   const [rawSystems, setRawSystems] = useState<StarSystemType[]>([]);
   const [factions, setFactions] = useState<FactionDataType>({});
   const [capitals, setCapitals] = useState<string[]>([]);
-  let baseUrl = import.meta.env.VITE_API_URL as string;
 
-  if (!baseUrl){
-    baseUrl = 'https://roguewar.org';
-  }
 
   const fetchFactionData = async () => {
     try {
       const factionData = await fetch(
-        `${baseUrl}/api/v1/factions/warmap`
+        `${API_BASE_URL}/api/v1/factions/warmap`
       ).then((res) => res.json());
 
       factionData['NoFaction'] = {
@@ -40,7 +37,7 @@ const useWarmapAPI = () => {
   const fetchSystemData = async () => {
     try {
       const systemData = await fetch(
-        `${baseUrl}/api/v1/starmap/warmap`
+        `${API_BASE_URL}/api/v1/starmap/warmap`
       ).then((res) => res.json());
 
       setRawSystems(systemData);

--- a/src/components/hooks/useWarmapAPI.ts
+++ b/src/components/hooks/useWarmapAPI.ts
@@ -5,11 +5,16 @@ const useWarmapAPI = () => {
   const [rawSystems, setRawSystems] = useState<StarSystemType[]>([]);
   const [factions, setFactions] = useState<FactionDataType>({});
   const [capitals, setCapitals] = useState<string[]>([]);
+  let baseUrl = import.meta.env.VITE_API_URL as string;
+
+  if (!baseUrl){
+    baseUrl = 'https://roguewar.org';
+  }
 
   const fetchFactionData = async () => {
     try {
       const factionData = await fetch(
-        'https://roguewar.org/api/v1/factions/warmap'
+        `${baseUrl}/api/v1/factions/warmap`
       ).then((res) => res.json());
 
       factionData['NoFaction'] = {
@@ -35,7 +40,7 @@ const useWarmapAPI = () => {
   const fetchSystemData = async () => {
     try {
       const systemData = await fetch(
-        'https://roguewar.org/api/v1/starmap/warmap'
+        `${baseUrl}/api/v1/starmap/warmap`
       ).then((res) => res.json());
 
       setRawSystems(systemData);

--- a/src/components/ui/StarSystem.tsx
+++ b/src/components/ui/StarSystem.tsx
@@ -8,6 +8,7 @@ import {
   Settings,
   StarSystemType,
 } from '../hooks/types';
+import { API_BASE_URL } from '../helpers/ApiHelper.ts';
 
 const CAPITAL_RADIUS = 2.5;
 const PLANET_RADIUS = 1;
@@ -93,7 +94,7 @@ const StarSystem: React.FC<StarSystemProps> = ({
       radius={radius}
       onDblClick={() => {
         if (system.sysUrl) {
-          openInNewTab(`https://www.roguewar.org${system.sysUrl}`);
+          openInNewTab(`${API_BASE_URL}${system.sysUrl}`);
         }
       }}
       onMouseEnter={(e) => {
@@ -127,7 +128,7 @@ const StarSystem: React.FC<StarSystemProps> = ({
           if (!pointer) return;
 
           if (tooltip.visible && tooltip.text.includes(system.name)) {
-            window.location.href = `https://www.roguewar.org${system.sysUrl}`;
+            window.location.href = `${API_BASE_URL}${system.sysUrl}`;
             return;
           }
 
@@ -144,7 +145,7 @@ const StarSystem: React.FC<StarSystemProps> = ({
             undefined,
             undefined,
             () => {
-              window.location.href = `https://www.roguewar.org${system.sysUrl}`;
+              window.location.href = `${API_BASE_URL}${system.sysUrl}`;
             }
           );
         }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import react from '@vitejs/plugin-react-swc';
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   return {
-    base: mode === 'development' ? '/' : env.VITE_BASE_URL,
+    base: mode === 'development' ? '/' : '/map',
     plugins: [react()],
   };
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig,loadEnv } from ' vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 
 // https://vitejs.dev/config/

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,6 @@ import react from '@vitejs/plugin-react-swc';
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
-  base: mode === 'development' ? '/' : '/map/',
+  base: mode === 'development' ? '/' : import.meta.env.BASE_URL,
   plugins: [react()],
 }));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,11 @@
-import { defineConfig } from 'vite';
+import { defineConfig,loadEnv } from ' vite';
 import react from '@vitejs/plugin-react-swc';
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
-  base: mode === 'development' ? '/' : import.meta.env.BASE_URL,
-  plugins: [react()],
-}));
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  return {
+    base: mode === 'development' ? '/' : env.BASE_URL,
+    plugins: [react()],
+  };
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import react from '@vitejs/plugin-react-swc';
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   return {
-    base: mode === 'development' ? '/' : env.BASE_URL,
+    base: mode === 'development' ? '/' : env.VITE_BASE_URL,
     plugins: [react()],
   };
 });


### PR DESCRIPTION
Allow the base url for the API/starsystem redirects to be changed via the .env files during build time.

also allow for the route from which the app is served to be set, allowing for better embedding into the existing RTO website.

Note: Please Squash when merging.