### PR TITLE
Add system coords to tooltip, increase hitstroke width

### DIFF
--- a/src/components/ui/StarSystem.tsx
+++ b/src/components/ui/StarSystem.tsx
@@ -91,6 +91,7 @@ const StarSystem: React.FC<StarSystemProps> = ({
       y={-Number(system.posY)}
       fill={system.factionColour}
       radius={radius}
+      hitStrokeWidth={3}
       onDblClick={() => {
         if (system.sysUrl) {
           openInNewTab(`https://www.roguewar.org${system.sysUrl}`);
@@ -107,7 +108,7 @@ const StarSystem: React.FC<StarSystemProps> = ({
         const controlDetails = formatFactionControl(system.factions, factions);
 
         showTooltip(
-          `${system.name}\n${
+          `${system.name}\nCoords: (${system.posX}, ${system.posY})\n${
             faction?.prettyName || 'Unknown'
           }\n\nFaction Control:\n${controlDetails}`,
           pointer.x,
@@ -138,7 +139,7 @@ const StarSystem: React.FC<StarSystemProps> = ({
           );
 
           showTooltip(
-            `${system.name}\n${faction?.prettyName}\n\nFaction Control:\n${controlDetails}\n\n[Tap to open]`,
+            `${system.name}\nCoords: (${system.posX}, ${system.posY})\n${faction?.prettyName}\n\nFaction Control:\n${controlDetails}\n\n[Tap to open]`,
             pointer.x,
             pointer.y,
             undefined,


### PR DESCRIPTION
Added system coordinates to tooltip, made it easier to select system on mouseover and tap