### PR TITLE
Remove unused dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,20 +11,14 @@
   },
   "dependencies": {
     "@material-tailwind/react": "^2.1.10",
-    "axios": "^1.13.2",
     "konva": "^9.3.18",
-    "localforage": "^1.10.0",
     "lucide-react": "^0.515.0",
-    "match-sorter": "^6.3.4",
-    "prop-types": "^15.8.1",
     "react": "^18.3.1",
-    "react-axios": "^2.0.6",
     "react-dom": "^18.3.1",
     "react-icons": "^5.3.0",
     "react-konva": "18",
     "react-router-dom": "^6.26.2",
-    "react-select": "^5.10.1",
-    "swr": "^2.2.5"
+    "react-select": "^5.10.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/tests/dependencies.test.ts
+++ b/tests/dependencies.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const REMOVED_PACKAGES = [
+  'axios',
+  'react-axios',
+  'localforage',
+  'match-sorter',
+  'prop-types',
+  'swr',
+];
+
+const SRC_DIR = path.resolve(__dirname, '../src');
+
+function collectFiles(dir: string): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectFiles(full));
+    } else if (/\.(ts|tsx|js|jsx)$/.test(entry.name)) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+describe('unused dependencies are not imported', () => {
+  const files = collectFiles(SRC_DIR);
+
+  for (const pkg of REMOVED_PACKAGES) {
+    it(`no src/ file imports "${pkg}"`, () => {
+      for (const file of files) {
+        const content = fs.readFileSync(file, 'utf-8');
+        const importPattern = new RegExp(
+          `(?:import|require)\\s*(?:\\(|.*from\\s*)['"]${pkg}(?:[/'"])`
+        );
+        expect(
+          importPattern.test(content),
+          `Found import of "${pkg}" in ${path.relative(SRC_DIR, file)}`
+        ).toBe(false);
+      }
+    });
+  }
+});
+
+describe('removed packages are not in package.json', () => {
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8')
+  );
+  const allDeps = {
+    ...packageJson.dependencies,
+    ...packageJson.devDependencies,
+  };
+
+  for (const pkg of REMOVED_PACKAGES) {
+    it(`"${pkg}" is not listed as a dependency`, () => {
+      expect(allDeps).not.toHaveProperty(pkg);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Removes 6 unused packages from `package.json`: `axios`, `react-axios`, `localforage`, `match-sorter`, `prop-types`, `swr`
- None of these packages are imported anywhere in `src/`
- Reduces install footprint and eliminates unnecessary maintenance burden

## Tests
- Adds `tests/dependencies.test.ts` — verifies removed packages are not imported in `src/` and not listed in `package.json`
- All existing tests continue to pass
- Build succeeds

## Disclosure
This PR was AI-generated using Claude Code (Anthropic). A review of the repository found no contribution guidelines, CODE_OF_CONDUCT.md, or any policy explicitly disallowing AI-generated contributions.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)