### PR TITLE
Remove console.log and console.error from production code

### DIFF
--- a/src/components/hooks/useWarmapAPI.ts
+++ b/src/components/hooks/useWarmapAPI.ts
@@ -29,8 +29,8 @@ const useWarmapAPI = () => {
       });
 
       setCapitals(capitals);
-    } catch (error) {
-      console.error('Failed to fetch data:', error);
+    } catch {
+      // Error handling deferred to Phase 2 (H4)
     }
   };
 
@@ -41,8 +41,8 @@ const useWarmapAPI = () => {
       ).then((res) => res.json());
 
       setRawSystems(systemData);
-    } catch (error) {
-      console.error('Failed to fetch data:', error);
+    } catch {
+      // Error handling deferred to Phase 2 (H4)
     }
   };
 

--- a/src/components/pages/GalaxyMap.tsx
+++ b/src/components/pages/GalaxyMap.tsx
@@ -30,14 +30,12 @@ const GalaxyMap = () => {
 
   useEffect(() => {
     if (!initialDataLoaded) {
-      console.log('Loading data...');
       fetchFactionData();
       fetchSystemData();
       setInitialDataLoaded(true);
     }
 
     const interval = setInterval(() => {
-      console.log('API Data Refreshing at', new Date().toLocaleTimeString());
       fetchSystemData();
     }, 300_000);
 

--- a/tests/no-console.test.ts
+++ b/tests/no-console.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SRC_DIR = path.resolve(__dirname, '../src');
+
+function collectFiles(dir: string): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectFiles(full));
+    } else if (/\.(ts|tsx|js|jsx)$/.test(entry.name)) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+describe('no console statements in production code', () => {
+  const files = collectFiles(SRC_DIR);
+
+  it('no console.log calls in src/', () => {
+    const violations: string[] = [];
+    for (const file of files) {
+      const content = fs.readFileSync(file, 'utf-8');
+      const lines = content.split('\n');
+      lines.forEach((line, i) => {
+        if (/\bconsole\.log\b/.test(line) && !line.trimStart().startsWith('//')) {
+          violations.push(`${path.relative(SRC_DIR, file)}:${i + 1}`);
+        }
+      });
+    }
+    expect(violations, `Found console.log in:\n${violations.join('\n')}`).toEqual([]);
+  });
+
+  it('no console.error calls in src/', () => {
+    const violations: string[] = [];
+    for (const file of files) {
+      const content = fs.readFileSync(file, 'utf-8');
+      const lines = content.split('\n');
+      lines.forEach((line, i) => {
+        if (/\bconsole\.error\b/.test(line) && !line.trimStart().startsWith('//')) {
+          violations.push(`${path.relative(SRC_DIR, file)}:${i + 1}`);
+        }
+      });
+    }
+    expect(violations, `Found console.error in:\n${violations.join('\n')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Removes `console.log` debug statements from `GalaxyMap.tsx`
- Removes `console.error` calls from `useWarmapAPI.ts`
- Proper error handling/UI will be addressed in a follow-up PR

## Tests
- Adds `tests/no-console.test.ts` — scans all `src/` files to prevent reintroduction of console statements
- All existing tests continue to pass
- Build succeeds

## Disclosure
This PR was AI-generated using Claude Code (Anthropic). A review of the repository found no contribution guidelines, CODE_OF_CONDUCT.md, or any policy explicitly disallowing AI-generated contributions.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)