### PR TITLE
Fix invalid Tailwind class in SideMenu

### DIFF
--- a/src/components/core/SideMenu.tsx
+++ b/src/components/core/SideMenu.tsx
@@ -34,7 +34,7 @@ export function SideMenu() {
           <MenuItem icon={FaMap} label="Map" path="/map" key="Map" />
         </ul>
       </nav>
-      <div className="absolute inset-x-0 bottom-0 h-16 items-center text-2x text-white">
+      <div className="absolute inset-x-0 bottom-0 h-16 items-center text-2xl text-white">
         <Link to="/tos" className="inline-">
           <FaList className="inline-block w-4 h-4 mr-2 -mt-1" />
           Terms of Data Use

--- a/tests/tailwind-classes.test.ts
+++ b/tests/tailwind-classes.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SRC_DIR = path.resolve(__dirname, '../src');
+
+function collectFiles(dir: string): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectFiles(full));
+    } else if (/\.(ts|tsx|js|jsx)$/.test(entry.name)) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+/**
+ * Known invalid Tailwind classes that have been found and fixed.
+ * Each pattern is a regex that should NOT appear in any className string.
+ */
+const INVALID_CLASS_PATTERNS = [
+  { pattern: /\btext-2x\b/, description: 'text-2x (should be text-2xl)' },
+];
+
+describe('no known invalid Tailwind classes in src/', () => {
+  const files = collectFiles(SRC_DIR);
+
+  for (const { pattern, description } of INVALID_CLASS_PATTERNS) {
+    it(`no occurrences of "${description}"`, () => {
+      const violations: string[] = [];
+      for (const file of files) {
+        const content = fs.readFileSync(file, 'utf-8');
+        const lines = content.split('\n');
+        lines.forEach((line, i) => {
+          if (pattern.test(line)) {
+            violations.push(`${path.relative(SRC_DIR, file)}:${i + 1}`);
+          }
+        });
+      }
+      expect(violations, `Found ${description} in:\n${violations.join('\n')}`).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Fixes `text-2x` (invalid, no effect) to `text-2xl` in `SideMenu.tsx`
- The ToS link at the bottom of the sidebar now renders at the intended font size

## Tests
- Adds `tests/tailwind-classes.test.ts` — checks for known invalid Tailwind classes across `src/`
- All existing tests continue to pass
- Build succeeds

## Disclosure
This PR was AI-generated using Claude Code (Anthropic). A review of the repository found no contribution guidelines, CODE_OF_CONDUCT.md, or any policy explicitly disallowing AI-generated contributions.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)