### PR TITLE
Remove conflicting height class from HomeCard

### DIFF
--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -35,7 +35,7 @@ export function HomeCard({
 
   return (
     <Card
-      className={`mt-6 w-96 h-56 border-2 ${borderColor} p-5 rounded-lg ml-14 inline-block h-96 relative grow-0`}
+      className={`mt-6 w-96 border-2 ${borderColor} p-5 rounded-lg ml-14 inline-block h-96 relative grow-0`}
     >
       <CardHeader className={`relative font-bold ${textColor}`}>
         {heading}

--- a/tests/conflicting-classes.test.ts
+++ b/tests/conflicting-classes.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SRC_DIR = path.resolve(__dirname, '../src');
+
+function collectFiles(dir: string): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectFiles(full));
+    } else if (/\.(ts|tsx|js|jsx)$/.test(entry.name)) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+/**
+ * Extracts all Tailwind height classes (h-*) from a className string.
+ * Returns an array of matches.
+ */
+function extractHeightClasses(className: string): string[] {
+  return className.match(/\bh-\d+\b/g) || [];
+}
+
+describe('no conflicting Tailwind height classes', () => {
+  const files = collectFiles(SRC_DIR);
+
+  it('no element has multiple h-* classes in the same className', () => {
+    const violations: string[] = [];
+
+    for (const file of files) {
+      const content = fs.readFileSync(file, 'utf-8');
+      // Match className strings (both static and template literals)
+      const classNameRegex = /className[=](?:{?`([^`]*)`}?|"([^"]*)")/g;
+      let match;
+      while ((match = classNameRegex.exec(content)) !== null) {
+        const classValue = match[1] || match[2] || '';
+        const heightClasses = extractHeightClasses(classValue);
+        if (heightClasses.length > 1) {
+          const line = content.substring(0, match.index).split('\n').length;
+          violations.push(
+            `${path.relative(SRC_DIR, file)}:${line} — conflicting: ${heightClasses.join(', ')}`
+          );
+        }
+      }
+    }
+
+    expect(
+      violations,
+      `Found conflicting height classes:\n${violations.join('\n')}`
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Removes duplicate `h-56` from HomeCard's className in `Home.tsx`
- The element had both `h-56` and `h-96`; since `h-96` appears later it wins, making `h-56` dead code

## Tests
- Adds `tests/conflicting-classes.test.ts` — detects elements with multiple `h-*` classes in the same className
- All existing tests continue to pass
- Build succeeds

## Disclosure
This PR was AI-generated using Claude Code (Anthropic). A review of the repository found no contribution guidelines, CODE_OF_CONDUCT.md, or any policy explicitly disallowing AI-generated contributions.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)