### PR TITLE
Replace any[] with typed UseTooltipReturn

### DIFF
--- a/src/components/hooks/useTooltip.ts
+++ b/src/components/hooks/useTooltip.ts
@@ -8,7 +8,20 @@ interface TooltipState {
   onTouch?: () => void;
 }
 
-const useTooltip = (scaleRef: React.RefObject<number>) => {
+export interface UseTooltipReturn {
+  tooltip: TooltipState;
+  showTooltip: (
+    text: string,
+    pointerX: number,
+    pointerY: number,
+    stageX?: number,
+    stageY?: number,
+    onTouch?: () => void
+  ) => void;
+  hideTooltip: () => void;
+}
+
+const useTooltip = (scaleRef: React.RefObject<number>): UseTooltipReturn => {
   const [tooltip, setTooltip] = useState<TooltipState>({
     visible: false,
     text: '',

--- a/src/components/pages/GalaxyMap.tsx
+++ b/src/components/pages/GalaxyMap.tsx
@@ -1,7 +1,6 @@
 import {
   Point,
   StageSize,
-  TooltipData,
   ViewTransform,
   GalaxyMapRenderProps,
 } from '../GalaxyMap/gm.types';
@@ -10,7 +9,7 @@ import Konva from 'konva';
 import { Stage, Layer, Image, Text, Label, Tag } from 'react-konva';
 import StarSystem from '../ui/StarSystem';
 import BottomFilterPanel from '../ui/BottomFilterPanel';
-import useTooltip from '../hooks/useTooltip';
+import useTooltip, { type UseTooltipReturn } from '../hooks/useTooltip';
 import useFiltering from '../hooks/useFiltering';
 
 const MIN_SCALE = 0.2;
@@ -82,11 +81,7 @@ const GalaxyMapRender = ({
   const [selectedFactions, setSelectedFactions] = useState<string[]>([]);
 
   const scaleRef = useRef(1);
-  const { tooltip, showTooltip, hideTooltip } = useTooltip(scaleRef) as {
-    tooltip: TooltipData;
-    showTooltip: (...args: any[]) => void;
-    hideTooltip: () => void;
-  };
+  const { tooltip, showTooltip, hideTooltip }: UseTooltipReturn = useTooltip(scaleRef);
   const stageRef = useRef<Konva.Stage | null>(null);
   const positionRef = useRef<Point>({
     x: window.innerWidth / 2,

--- a/tests/no-any-types.test.ts
+++ b/tests/no-any-types.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SRC_DIR = path.resolve(__dirname, '../src');
+
+function collectFiles(dir: string): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectFiles(full));
+    } else if (/\.(ts|tsx)$/.test(entry.name)) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+describe('no unsafe any types in production code', () => {
+  const files = collectFiles(SRC_DIR);
+
+  it('no any[] parameter types in src/', () => {
+    const violations: string[] = [];
+    for (const file of files) {
+      const content = fs.readFileSync(file, 'utf-8');
+      const lines = content.split('\n');
+      lines.forEach((line, i) => {
+        const trimmed = line.trimStart();
+        // Skip comments
+        if (trimmed.startsWith('//') || trimmed.startsWith('*')) return;
+        if (/\bany\[\]/.test(line)) {
+          violations.push(`${path.relative(SRC_DIR, file)}:${i + 1}: ${trimmed}`);
+        }
+      });
+    }
+    expect(
+      violations,
+      `Found any[] usage in:\n${violations.join('\n')}`
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Exports `UseTooltipReturn` interface from `useTooltip.ts` with the full typed `showTooltip` signature
- Replaces `(...args: any[]) => void` cast in `GalaxyMap.tsx` with the proper typed interface
- Removes now-unused `TooltipData` import from `GalaxyMap.tsx`

## Tests
- Adds `tests/no-any-types.test.ts` — scans all `src/` TypeScript files to prevent `any[]` usage
- All existing tests pass, build succeeds

## Disclosure
This PR was AI-generated using Claude Code (Anthropic). A review of the repository found no contribution guidelines, CODE_OF_CONDUCT.md, or any policy explicitly disallowing AI-generated contributions.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)