### PR TITLE
Add error and loading states to API layer and map UI

### DIFF
--- a/src/components/hooks/useFiltering.ts
+++ b/src/components/hooks/useFiltering.ts
@@ -8,7 +8,7 @@ const useFiltering = () => {
   const [displaySystems, setDisplaySystems] = useState<DisplayStarSystemType[]>(
     []
   );
-  const { rawSystems, factions, capitals, fetchFactionData, fetchSystemData } =
+  const { rawSystems, factions, capitals, fetchFactionData, fetchSystemData, isLoading, error } =
     useWarmapAPI();
 
   const { settings, setFlashActive } = useSettings();
@@ -45,6 +45,8 @@ const useFiltering = () => {
     fetchSystemData,
     settings,
     setFlashActive,
+    isLoading,
+    error,
   };
 };
 

--- a/src/components/hooks/useWarmapAPI.ts
+++ b/src/components/hooks/useWarmapAPI.ts
@@ -6,13 +6,16 @@ const useWarmapAPI = () => {
   const [rawSystems, setRawSystems] = useState<StarSystemType[]>([]);
   const [factions, setFactions] = useState<FactionDataType>({});
   const [capitals, setCapitals] = useState<string[]>([]);
-
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   const fetchFactionData = async () => {
+    setIsLoading(true);
+    setError(null);
     try {
-      const factionData = await fetch(
-        `${API_BASE_URL}/api/v1/factions/warmap`
-      ).then((res) => res.json());
+      const res = await fetch(`${API_BASE_URL}/api/v1/factions/warmap`);
+      if (!res.ok) throw new Error(`Faction API returned ${res.status}`);
+      const factionData = await res.json();
 
       factionData['NoFaction'] = {
         colour: 'gray',
@@ -29,20 +32,23 @@ const useWarmapAPI = () => {
       });
 
       setCapitals(capitals);
-    } catch (error) {
-      console.error('Failed to fetch data:', error);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch faction data');
+    } finally {
+      setIsLoading(false);
     }
   };
 
   const fetchSystemData = async () => {
+    setError(null);
     try {
-      const systemData = await fetch(
-        `${API_BASE_URL}/api/v1/starmap/warmap`
-      ).then((res) => res.json());
+      const res = await fetch(`${API_BASE_URL}/api/v1/starmap/warmap`);
+      if (!res.ok) throw new Error(`System API returned ${res.status}`);
+      const systemData = await res.json();
 
       setRawSystems(systemData);
-    } catch (error) {
-      console.error('Failed to fetch data:', error);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch system data');
     }
   };
 
@@ -52,6 +58,8 @@ const useWarmapAPI = () => {
     capitals,
     fetchFactionData,
     fetchSystemData,
+    isLoading,
+    error,
   };
 };
 

--- a/src/components/pages/GalaxyMap.tsx
+++ b/src/components/pages/GalaxyMap.tsx
@@ -24,20 +24,20 @@ const GalaxyMap = () => {
     fetchFactionData,
     fetchSystemData,
     settings,
+    isLoading,
+    error,
   } = useFiltering();
 
   const [initialDataLoaded, setInitialDataLoaded] = useState<boolean>(false);
 
   useEffect(() => {
     if (!initialDataLoaded) {
-      console.log('Loading data...');
       fetchFactionData();
       fetchSystemData();
       setInitialDataLoaded(true);
     }
 
     const interval = setInterval(() => {
-      console.log('API Data Refreshing at', new Date().toLocaleTimeString());
       fetchSystemData();
     }, 300_000);
 
@@ -50,23 +50,91 @@ const GalaxyMap = () => {
     initialDataLoaded,
   ]);
 
-  if (
-    displaySystems &&
-    displaySystems.length > 0 &&
-    factions &&
-    capitals &&
-    capitals.length > 0
-  ) {
+  if (error) {
     return (
-      <GalaxyMapRender
-        systems={displaySystems}
-        factions={factions}
-        settings={settings}
-      />
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: '100vh',
+          backgroundColor: '#1a1a2e',
+          color: '#e0e0e0',
+          fontFamily: 'system-ui, sans-serif',
+          textAlign: 'center',
+          padding: '2rem',
+        }}
+      >
+        <h1 style={{ fontSize: '1.5rem', marginBottom: '1rem' }}>
+          Failed to load map data
+        </h1>
+        <p style={{ marginBottom: '1.5rem', opacity: 0.8 }}>{error}</p>
+        <button
+          onClick={() => {
+            fetchFactionData();
+            fetchSystemData();
+          }}
+          style={{
+            padding: '0.5rem 1.5rem',
+            backgroundColor: '#4a90d9',
+            color: 'white',
+            border: 'none',
+            borderRadius: '0.375rem',
+            cursor: 'pointer',
+            fontSize: '1rem',
+          }}
+        >
+          Retry
+        </button>
+      </div>
     );
   }
 
-  return null;
+  if (
+    isLoading ||
+    !displaySystems ||
+    displaySystems.length === 0 ||
+    !factions ||
+    !capitals ||
+    capitals.length === 0
+  ) {
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: '100vh',
+          backgroundColor: '#1a1a2e',
+          color: '#e0e0e0',
+          fontFamily: 'system-ui, sans-serif',
+        }}
+      >
+        <div
+          style={{
+            width: '3rem',
+            height: '3rem',
+            border: '3px solid rgba(255,255,255,0.2)',
+            borderTopColor: '#4a90d9',
+            borderRadius: '50%',
+            animation: 'spin 0.8s linear infinite',
+          }}
+        />
+        <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+        <p style={{ marginTop: '1rem', opacity: 0.8 }}>Loading map data...</p>
+      </div>
+    );
+  }
+
+  return (
+    <GalaxyMapRender
+      systems={displaySystems}
+      factions={factions}
+      settings={settings}
+    />
+  );
 };
 
 const GalaxyMapRender = ({

--- a/tests/api-states.test.ts
+++ b/tests/api-states.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const readSrc = (relativePath: string) =>
+  fs.readFileSync(path.resolve(__dirname, '../src', relativePath), 'utf-8');
+
+describe('API error and loading states', () => {
+  describe('useWarmapAPI', () => {
+    const content = readSrc('components/hooks/useWarmapAPI.ts');
+
+    it('tracks isLoading state', () => {
+      expect(content).toContain('isLoading');
+      expect(content).toContain('setIsLoading');
+    });
+
+    it('tracks error state', () => {
+      expect(content).toContain("useState<string | null>(null)");
+      expect(content).toContain('setError');
+    });
+
+    it('returns isLoading and error', () => {
+      expect(content).toMatch(/return\s*\{[\s\S]*isLoading[\s\S]*\}/);
+      expect(content).toMatch(/return\s*\{[\s\S]*error[\s\S]*\}/);
+    });
+
+    it('sets isLoading false in finally block', () => {
+      expect(content).toContain('finally');
+      expect(content).toContain('setIsLoading(false)');
+    });
+
+    it('checks response.ok before parsing JSON', () => {
+      expect(content).toContain('res.ok');
+    });
+  });
+
+  describe('useFiltering', () => {
+    const content = readSrc('components/hooks/useFiltering.ts');
+
+    it('passes through isLoading from useWarmapAPI', () => {
+      expect(content).toContain('isLoading');
+    });
+
+    it('passes through error from useWarmapAPI', () => {
+      expect(content).toContain('error');
+    });
+  });
+
+  describe('GalaxyMap', () => {
+    const content = readSrc('components/pages/GalaxyMap.tsx');
+
+    it('destructures isLoading and error from useFiltering', () => {
+      expect(content).toContain('isLoading');
+      expect(content).toContain('error');
+    });
+
+    it('does not return bare null for loading state', () => {
+      // The old code had just "return null;" with no loading UI.
+      // Verify there is a loading message instead.
+      expect(content).toContain('Loading map data...');
+    });
+
+    it('shows error UI with retry button', () => {
+      expect(content).toContain('Failed to load map data');
+      expect(content).toContain('Retry');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `useWarmapAPI` now tracks `isLoading` and `error` states with descriptive error messages
- Validates `response.ok` before parsing JSON to catch HTTP errors
- States flow through `useFiltering` to `GalaxyMap` component
- GalaxyMap now shows a loading spinner during initial data fetch instead of a blank screen
- Shows an error screen with retry button when API calls fail
- Removes `console.log` statements from data fetching lifecycle

## Tests
- Adds `tests/api-states.test.ts` — verifies error/loading state plumbing across all three layers and UI presence
- All existing tests pass, build succeeds

## Test plan
- [ ] Verify loading spinner appears on initial page load before data arrives
- [ ] Verify map renders normally once data loads
- [ ] Verify error screen with retry button appears when API is unreachable
- [ ] Verify retry button re-triggers data fetch

## Disclosure
This PR was AI-generated using Claude Code (Anthropic). A review of the repository found no contribution guidelines, CODE_OF_CONDUCT.md, or any policy explicitly disallowing AI-generated contributions.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)