### PR TITLE
Extract gesture, zoom, and pinch logic from GalaxyMapRender into hooks

### DIFF
--- a/src/components/hooks/canvasUtils.ts
+++ b/src/components/hooks/canvasUtils.ts
@@ -1,0 +1,18 @@
+import Konva from 'konva';
+
+export function getDistance(touch1: Touch, touch2: Touch): number {
+  const dx = touch1.clientX - touch2.clientX;
+  const dy = touch1.clientY - touch2.clientY;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+let frameRequested = false;
+export function requestBatchDraw(stage: Konva.Stage): void {
+  if (!frameRequested) {
+    frameRequested = true;
+    requestAnimationFrame(() => {
+      stage.batchDraw();
+      frameRequested = false;
+    });
+  }
+}

--- a/src/components/hooks/usePinchZoom.ts
+++ b/src/components/hooks/usePinchZoom.ts
@@ -1,0 +1,116 @@
+import { useRef, useState } from 'react';
+import Konva from 'konva';
+import type { Point } from '../GalaxyMap/gm.types';
+import { getDistance, requestBatchDraw } from './canvasUtils';
+
+const MIN_SCALE = 0.2;
+const MAX_SCALE = 25;
+
+const usePinchZoom = (
+  stageRef: React.RefObject<Konva.Stage | null>,
+  scaleRef: React.MutableRefObject<number>,
+  positionRef: React.MutableRefObject<Point>,
+  hideTooltip: () => void,
+  onScaleChange: (scale: number) => void
+) => {
+  const [isPinching, setIsPinching] = useState(false);
+  const lastDistance = useRef(0);
+  const pinchMidpoint = useRef<Point | null>(null);
+
+  const handleTouchStart = (e: Konva.KonvaEventObject<TouchEvent>) => {
+    if (e.evt.touches.length === 1) {
+      const stage = e.target.getStage();
+      if (!stage) return;
+      const isCircle = e.target.className === 'Circle';
+      const isTooltip = e.target.findAncestor('Label', true);
+      if (!isCircle && !isTooltip) {
+        hideTooltip();
+      }
+    }
+
+    if (e.evt.touches.length === 2) {
+      setIsPinching(true);
+      lastDistance.current = getDistance(e.evt.touches[0], e.evt.touches[1]);
+
+      pinchMidpoint.current = {
+        x: (e.evt.touches[0].clientX + e.evt.touches[1].clientX) / 2,
+        y: (e.evt.touches[0].clientY + e.evt.touches[1].clientY) / 2,
+      };
+    }
+  };
+
+  const handleTouchMove = (e: Konva.KonvaEventObject<TouchEvent>) => {
+    if (e.evt.touches.length === 2 && isPinching) {
+      e.evt.preventDefault();
+
+      if (!pinchMidpoint.current) return;
+
+      const [touch1, touch2] = e.evt.touches;
+      const newDistance = getDistance(touch1, touch2);
+
+      if (!lastDistance.current) return;
+
+      const stage = stageRef.current;
+
+      if (!stage) return;
+
+      let scaleBy = newDistance / lastDistance.current;
+
+      // Prevent jitter and dead zone on Firefox
+      if (Math.abs(1 - scaleBy) < 0.02) return;
+
+      // Clamp to avoid huge jumps
+      scaleBy = Math.max(0.9, Math.min(1.1, scaleBy));
+
+      const newScale = Math.max(
+        MIN_SCALE,
+        Math.min(MAX_SCALE, scaleRef.current * scaleBy)
+      );
+
+      const stagePos = stage.getPosition();
+      const stageScale = stage.scaleX();
+
+      const pinchCenter = {
+        x: (touch1.clientX + touch2.clientX) / 2,
+        y: (touch1.clientY + touch2.clientY) / 2,
+      };
+
+      const worldPos = {
+        x: (pinchCenter.x - stagePos.x) / stageScale,
+        y: (pinchCenter.y - stagePos.y) / stageScale,
+      };
+
+      requestAnimationFrame(() => {
+        const newPos = {
+          x: pinchCenter.x - worldPos.x * newScale,
+          y: pinchCenter.y - worldPos.y * newScale,
+        };
+
+        scaleRef.current = newScale;
+        positionRef.current = newPos;
+
+        stage.scale({ x: newScale, y: newScale });
+        stage.position(newPos);
+        requestBatchDraw(stage);
+        onScaleChange(newScale < 1 ? newScale : 1);
+      });
+
+      lastDistance.current = newDistance;
+    }
+  };
+
+  const handleTouchEnd = (e: Konva.KonvaEventObject<TouchEvent>) => {
+    if (e.evt.touches.length < 2) {
+      setIsPinching(false);
+    }
+  };
+
+  return {
+    isPinching,
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchEnd,
+  };
+};
+
+export default usePinchZoom;

--- a/src/components/hooks/usePreventBrowserZoom.ts
+++ b/src/components/hooks/usePreventBrowserZoom.ts
@@ -1,0 +1,104 @@
+import { useEffect, useState } from 'react';
+import Konva from 'konva';
+import type { StageSize } from '../GalaxyMap/gm.types';
+
+const usePreventBrowserZoom = (
+  stageRef: React.RefObject<Konva.Stage | null>
+) => {
+  const [stageSize, setStageSize] = useState<StageSize>({
+    width: window.innerWidth,
+    height: window.innerHeight,
+  });
+
+  // Block Firefox pinch-to-zoom at document level
+  useEffect(() => {
+    const preventZoomTouch = (e: TouchEvent) => {
+      if (e.touches.length > 1) {
+        e.preventDefault();
+      }
+    };
+
+    const preventZoomGesture: EventListener = (e) => {
+      e.preventDefault();
+    };
+
+    const options = { passive: false } as AddEventListenerOptions;
+
+    document.addEventListener('touchmove', preventZoomTouch, options);
+    document.addEventListener('gesturestart', preventZoomGesture, options);
+    document.addEventListener('gesturechange', preventZoomGesture, options);
+    document.addEventListener('gestureend', preventZoomGesture, options);
+
+    return () => {
+      document.removeEventListener('touchmove', preventZoomTouch, options);
+      document.removeEventListener('gesturestart', preventZoomGesture, options);
+      document.removeEventListener(
+        'gesturechange',
+        preventZoomGesture,
+        options
+      );
+      document.removeEventListener('gestureend', preventZoomGesture, options);
+    };
+  }, []);
+
+  // Extra locking gesture handling for Firefox
+  useEffect(() => {
+    const lockScale = (e: Event) => e.preventDefault();
+
+    window.addEventListener('gesturestart', lockScale, { passive: false });
+    window.addEventListener('gesturechange', lockScale, { passive: false });
+    window.addEventListener('gestureend', lockScale, { passive: false });
+
+    return () => {
+      window.removeEventListener('gesturestart', lockScale);
+      window.removeEventListener('gesturechange', lockScale);
+      window.removeEventListener('gestureend', lockScale);
+    };
+  }, []);
+
+  // Track window resize
+  useEffect(() => {
+    const handleResize = () => {
+      setStageSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  // Block gestures on Konva container
+  useEffect(() => {
+    const stage = stageRef.current;
+    if (!stage) return;
+
+    const container = stage.container();
+    const preventDefault = (e: Event) => {
+      if (e.cancelable) e.preventDefault();
+    };
+
+    container.addEventListener('gesturestart', preventDefault, {
+      passive: false,
+    });
+    container.addEventListener('gesturechange', preventDefault, {
+      passive: false,
+    });
+    container.addEventListener('gestureend', preventDefault, {
+      passive: false,
+    });
+    container.addEventListener('touchmove', preventDefault, { passive: false });
+
+    return () => {
+      container.removeEventListener('gesturestart', preventDefault);
+      container.removeEventListener('gesturechange', preventDefault);
+      container.removeEventListener('gestureend', preventDefault);
+      container.removeEventListener('touchmove', preventDefault);
+    };
+  }, [stageRef]);
+
+  return { stageSize };
+};
+
+export default usePreventBrowserZoom;

--- a/src/components/hooks/useZoomPan.ts
+++ b/src/components/hooks/useZoomPan.ts
@@ -1,0 +1,60 @@
+import { useRef } from 'react';
+import Konva from 'konva';
+import type { Point } from '../GalaxyMap/gm.types';
+import { requestBatchDraw } from './canvasUtils';
+
+const MIN_SCALE = 0.2;
+const MAX_SCALE = 25;
+const WHEEL_THROTTLE_MS = 50;
+
+const useZoomPan = (
+  stageRef: React.RefObject<Konva.Stage | null>,
+  scaleRef: React.MutableRefObject<number>,
+  positionRef: React.MutableRefObject<Point>,
+  onScaleChange: (scale: number) => void
+) => {
+  const lastWheelTime = useRef(0);
+
+  const handleWheel = (e: Konva.KonvaEventObject<WheelEvent>) => {
+    const now = performance.now();
+    if (now - lastWheelTime.current < WHEEL_THROTTLE_MS) return;
+
+    lastWheelTime.current = now;
+
+    e.evt.preventDefault();
+    const scaleBy = 1.25;
+    const stage = stageRef.current;
+    if (!stage) return;
+
+    const pointer = stage.getPointerPosition();
+    if (!pointer) return;
+
+    const oldScale = scaleRef.current;
+    let newScale = e.evt.deltaY > 0 ? oldScale / scaleBy : oldScale * scaleBy;
+    newScale = Math.max(MIN_SCALE, Math.min(MAX_SCALE, newScale));
+
+    const mousePointTo = {
+      x: (pointer.x - stage.x()) / oldScale,
+      y: (pointer.y - stage.y()) / oldScale,
+    };
+
+    scaleRef.current = newScale;
+    positionRef.current = {
+      x: pointer.x - mousePointTo.x * newScale,
+      y: pointer.y - mousePointTo.y * newScale,
+    };
+
+    stage.scale({ x: newScale, y: newScale });
+    stage.position(positionRef.current);
+    requestBatchDraw(stage);
+    onScaleChange(scaleRef.current < 1 ? scaleRef.current : 1);
+  };
+
+  const handleDragMove = (e: Konva.KonvaEventObject<DragEvent>) => {
+    positionRef.current = { x: e.target.x(), y: e.target.y() };
+  };
+
+  return { handleWheel, handleDragMove };
+};
+
+export default useZoomPan;

--- a/src/components/pages/GalaxyMap.tsx
+++ b/src/components/pages/GalaxyMap.tsx
@@ -1,6 +1,5 @@
 import {
   Point,
-  StageSize,
   TooltipData,
   ViewTransform,
   GalaxyMapRenderProps,
@@ -12,9 +11,9 @@ import StarSystem from '../ui/StarSystem';
 import BottomFilterPanel from '../ui/BottomFilterPanel';
 import useTooltip from '../hooks/useTooltip';
 import useFiltering from '../hooks/useFiltering';
-
-const MIN_SCALE = 0.2;
-const MAX_SCALE = 25;
+import usePreventBrowserZoom from '../hooks/usePreventBrowserZoom';
+import useZoomPan from '../hooks/useZoomPan';
+import usePinchZoom from '../hooks/usePinchZoom';
 
 const GalaxyMap = () => {
   const {
@@ -93,79 +92,22 @@ const GalaxyMapRender = ({
     y: window.innerHeight / 2,
   });
 
+  const [zoomScaleFactor, setZoomScaleFactor] = useState<number>(1);
+
+  const { stageSize } = usePreventBrowserZoom(stageRef);
+  const { handleWheel, handleDragMove } = useZoomPan(
+    stageRef,
+    scaleRef,
+    positionRef,
+    setZoomScaleFactor
+  );
+  const { isPinching, handleTouchStart, handleTouchMove, handleTouchEnd } =
+    usePinchZoom(stageRef, scaleRef, positionRef, hideTooltip, setZoomScaleFactor);
+
   const view: ViewTransform = {
     scale: scaleRef.current,
     position: positionRef.current,
   };
-
-  const [stageSize, setStageSize] = useState<StageSize>({
-    width: window.innerWidth,
-    height: window.innerHeight,
-  });
-
-  const [zoomScaleFactor, setZoomScaleFactor] = useState<number>(1);
-
-  // Block Firefox pinch-to-zoom at document level
-  useEffect(() => {
-    const preventZoomTouch = (e: TouchEvent) => {
-      if (e.touches.length > 1) {
-        e.preventDefault();
-      }
-    };
-
-    const preventZoomGesture: EventListener = (e) => {
-      e.preventDefault();
-    };
-
-    const options = { passive: false } as AddEventListenerOptions;
-
-    document.addEventListener('touchmove', preventZoomTouch, options);
-    document.addEventListener('gesturestart', preventZoomGesture, options);
-    document.addEventListener('gesturechange', preventZoomGesture, options);
-    document.addEventListener('gestureend', preventZoomGesture, options);
-
-    return () => {
-      document.removeEventListener('touchmove', preventZoomTouch, options);
-      document.removeEventListener('gesturestart', preventZoomGesture, options);
-      document.removeEventListener(
-        'gesturechange',
-        preventZoomGesture,
-        options
-      );
-      document.removeEventListener('gestureend', preventZoomGesture, options);
-    };
-  }, []);
-
-  // extra locking gesture handling for Firefox
-  useEffect(() => {
-    const lockScale = (e: Event) => e.preventDefault();
-
-    window.addEventListener('gesturestart', lockScale, { passive: false });
-    window.addEventListener('gesturechange', lockScale, { passive: false });
-    window.addEventListener('gestureend', lockScale, { passive: false });
-
-    return () => {
-      window.removeEventListener('gesturestart', lockScale);
-      window.removeEventListener('gesturechange', lockScale);
-      window.removeEventListener('gestureend', lockScale);
-    };
-  }, []);
-
-  useEffect(() => {
-    const handleResize = () => {
-      setStageSize({
-        width: window.innerWidth,
-        height: window.innerHeight,
-      });
-    };
-
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
-
-  const [isPinching, setIsPinching] = useState(false);
-  const lastDistance = useRef(0);
-  const pinchMidpoint = useRef<Point | null>(null);
 
   const [background, setBackground] = useState<HTMLImageElement | null>(null);
   const [bgLoaded, setBgLoaded] = useState(false);
@@ -186,181 +128,6 @@ const GalaxyMapRender = ({
       setBgLoaded(true);
     };
   }, []);
-
-  useEffect(() => {
-    const stage = stageRef.current;
-    if (!stage) return;
-
-    const container = stage.container();
-    const preventDefault = (e: Event) => {
-      if (e.cancelable) e.preventDefault();
-    };
-
-    container.addEventListener('gesturestart', preventDefault, {
-      passive: false,
-    });
-    container.addEventListener('gesturechange', preventDefault, {
-      passive: false,
-    });
-    container.addEventListener('gestureend', preventDefault, {
-      passive: false,
-    });
-    container.addEventListener('touchmove', preventDefault, { passive: false });
-
-    return () => {
-      container.removeEventListener('gesturestart', preventDefault);
-      container.removeEventListener('gesturechange', preventDefault);
-      container.removeEventListener('gestureend', preventDefault);
-      container.removeEventListener('touchmove', preventDefault);
-    };
-  }, []);
-
-  const getDistance = (touch1: Touch, touch2: Touch) => {
-    const dx = touch1.clientX - touch2.clientX;
-    const dy = touch1.clientY - touch2.clientY;
-    return Math.sqrt(dx * dx + dy * dy);
-  };
-
-  let frameRequested = false;
-  const requestBatchDraw = (stage: Konva.Stage) => {
-    if (!frameRequested) {
-      frameRequested = true;
-      requestAnimationFrame(() => {
-        stage.batchDraw();
-        frameRequested = false;
-      });
-    }
-  };
-
-  const lastWheelTime = useRef(0);
-  const WHEEL_THROTTLE_MS = 50;
-
-  const handleWheel = (e: Konva.KonvaEventObject<WheelEvent>) => {
-    const now = performance.now();
-    if (now - lastWheelTime.current < WHEEL_THROTTLE_MS) return;
-
-    lastWheelTime.current = now;
-
-    e.evt.preventDefault();
-    const scaleBy = 1.25;
-    const stage = stageRef.current;
-    if (!stage) return;
-
-    const pointer = stage.getPointerPosition();
-    if (!pointer) return;
-
-    const oldScale = scaleRef.current;
-    let newScale = e.evt.deltaY > 0 ? oldScale / scaleBy : oldScale * scaleBy;
-    newScale = Math.max(MIN_SCALE, Math.min(MAX_SCALE, newScale));
-
-    const mousePointTo = {
-      x: (pointer.x - stage.x()) / oldScale,
-      y: (pointer.y - stage.y()) / oldScale,
-    };
-
-    scaleRef.current = newScale;
-    positionRef.current = {
-      x: pointer.x - mousePointTo.x * newScale,
-      y: pointer.y - mousePointTo.y * newScale,
-    };
-
-    stage.scale({ x: newScale, y: newScale });
-    stage.position(positionRef.current);
-    requestBatchDraw(stage);
-    setZoomScaleFactor(scaleRef.current < 1 ? scaleRef.current : 1);
-  };
-
-  const handleDragMove = (e: Konva.KonvaEventObject<DragEvent>) => {
-    positionRef.current = { x: e.target.x(), y: e.target.y() };
-  };
-
-  const handleTouchStart = (e: Konva.KonvaEventObject<TouchEvent>) => {
-    if (e.evt.touches.length === 1) {
-      const stage = e.target.getStage();
-      if (!stage) return;
-      const isCircle = e.target.className === 'Circle';
-      const isTooltip = e.target.findAncestor('Label', true);
-      if (!isCircle && !isTooltip) {
-        hideTooltip();
-      }
-    }
-
-    if (e.evt.touches.length === 2) {
-      setIsPinching(true);
-      lastDistance.current = getDistance(e.evt.touches[0], e.evt.touches[1]);
-
-      pinchMidpoint.current = {
-        x: (e.evt.touches[0].clientX + e.evt.touches[1].clientX) / 2,
-        y: (e.evt.touches[0].clientY + e.evt.touches[1].clientY) / 2,
-      };
-    }
-  };
-
-  const handleTouchMove = (e: Konva.KonvaEventObject<TouchEvent>) => {
-    if (e.evt.touches.length === 2 && isPinching) {
-      e.evt.preventDefault();
-
-      if (!pinchMidpoint.current) return;
-
-      const [touch1, touch2] = e.evt.touches;
-      const newDistance = getDistance(touch1, touch2);
-
-      if (!lastDistance.current) return;
-
-      const stage = stageRef.current;
-
-      if (!stage) return;
-
-      let scaleBy = newDistance / lastDistance.current;
-
-      // Prevent jitter and dead zone on Firefox
-      if (Math.abs(1 - scaleBy) < 0.02) return;
-
-      // Clamp to avoid huge jumps
-      scaleBy = Math.max(0.9, Math.min(1.1, scaleBy));
-
-      const newScale = Math.max(
-        MIN_SCALE,
-        Math.min(MAX_SCALE, scaleRef.current * scaleBy)
-      );
-
-      const stagePos = stage.getPosition();
-      const stageScale = stage.scaleX();
-
-      const pinchCenter = {
-        x: (touch1.clientX + touch2.clientX) / 2,
-        y: (touch1.clientY + touch2.clientY) / 2,
-      };
-
-      const worldPos = {
-        x: (pinchCenter.x - stagePos.x) / stageScale,
-        y: (pinchCenter.y - stagePos.y) / stageScale,
-      };
-
-      requestAnimationFrame(() => {
-        const newPos = {
-          x: pinchCenter.x - worldPos.x * newScale,
-          y: pinchCenter.y - worldPos.y * newScale,
-        };
-
-        scaleRef.current = newScale;
-        positionRef.current = newPos;
-
-        stage.scale({ x: newScale, y: newScale });
-        stage.position(newPos);
-        requestBatchDraw(stage);
-        setZoomScaleFactor(newScale < 1 ? newScale : 1); // mirror wheel zoom behavior
-      });
-
-      lastDistance.current = newDistance;
-    }
-  };
-
-  const handleTouchEnd = (e: Konva.KonvaEventObject<TouchEvent>) => {
-    if (e.evt.touches.length < 2) {
-      setIsPinching(false);
-    }
-  };
 
   const isMobile = window.innerWidth < 768;
   const tooltipScale = isMobile ? 1.5 / view.scale : 2 / view.scale;
@@ -407,7 +174,7 @@ const GalaxyMapRender = ({
         </Layer>
         <Layer>
           {systems.map((system, index) => {
-            /* resolve owner’s display name the same way allFactionNames() did */
+            /* resolve owner's display name the same way allFactionNames() did */
             const ownerPretty =
               factions[system.owner]?.prettyName ?? system.owner;
             const factionMatch =

--- a/tests/galaxymap-hooks.test.ts
+++ b/tests/galaxymap-hooks.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const HOOKS_DIR = path.resolve(__dirname, '../src/components/hooks');
+const GALAXYMAP_PATH = path.resolve(
+  __dirname,
+  '../src/components/pages/GalaxyMap.tsx'
+);
+
+describe('GalaxyMap hook extraction', () => {
+  describe('canvasUtils', () => {
+    const filePath = path.join(HOOKS_DIR, 'canvasUtils.ts');
+
+    it('exists', () => {
+      expect(fs.existsSync(filePath)).toBe(true);
+    });
+
+    it('exports getDistance', () => {
+      const content = fs.readFileSync(filePath, 'utf-8');
+      expect(content).toContain('export function getDistance');
+    });
+
+    it('exports requestBatchDraw', () => {
+      const content = fs.readFileSync(filePath, 'utf-8');
+      expect(content).toContain('export function requestBatchDraw');
+    });
+  });
+
+  describe('usePreventBrowserZoom', () => {
+    const filePath = path.join(HOOKS_DIR, 'usePreventBrowserZoom.ts');
+
+    it('exists', () => {
+      expect(fs.existsSync(filePath)).toBe(true);
+    });
+
+    it('exports default hook', () => {
+      const content = fs.readFileSync(filePath, 'utf-8');
+      expect(content).toContain('export default usePreventBrowserZoom');
+    });
+
+    it('returns stageSize', () => {
+      const content = fs.readFileSync(filePath, 'utf-8');
+      expect(content).toContain('stageSize');
+    });
+
+    it('handles gesture prevention', () => {
+      const content = fs.readFileSync(filePath, 'utf-8');
+      expect(content).toContain('gesturestart');
+      expect(content).toContain('touchmove');
+    });
+  });
+
+  describe('useZoomPan', () => {
+    const filePath = path.join(HOOKS_DIR, 'useZoomPan.ts');
+
+    it('exists', () => {
+      expect(fs.existsSync(filePath)).toBe(true);
+    });
+
+    it('exports default hook', () => {
+      const content = fs.readFileSync(filePath, 'utf-8');
+      expect(content).toContain('export default useZoomPan');
+    });
+
+    it('returns handleWheel and handleDragMove', () => {
+      const content = fs.readFileSync(filePath, 'utf-8');
+      expect(content).toMatch(/return\s*\{[\s\S]*handleWheel[\s\S]*\}/);
+      expect(content).toMatch(/return\s*\{[\s\S]*handleDragMove[\s\S]*\}/);
+    });
+
+    it('uses shared requestBatchDraw', () => {
+      const content = fs.readFileSync(filePath, 'utf-8');
+      expect(content).toContain("from './canvasUtils'");
+    });
+  });
+
+  describe('usePinchZoom', () => {
+    const filePath = path.join(HOOKS_DIR, 'usePinchZoom.ts');
+
+    it('exists', () => {
+      expect(fs.existsSync(filePath)).toBe(true);
+    });
+
+    it('exports default hook', () => {
+      const content = fs.readFileSync(filePath, 'utf-8');
+      expect(content).toContain('export default usePinchZoom');
+    });
+
+    it('returns touch handlers and isPinching', () => {
+      const content = fs.readFileSync(filePath, 'utf-8');
+      expect(content).toContain('handleTouchStart');
+      expect(content).toContain('handleTouchMove');
+      expect(content).toContain('handleTouchEnd');
+      expect(content).toContain('isPinching');
+    });
+
+    it('uses shared getDistance and requestBatchDraw', () => {
+      const content = fs.readFileSync(filePath, 'utf-8');
+      expect(content).toContain("from './canvasUtils'");
+      expect(content).toContain('getDistance');
+      expect(content).toContain('requestBatchDraw');
+    });
+  });
+
+  describe('GalaxyMap.tsx integration', () => {
+    const content = fs.readFileSync(GALAXYMAP_PATH, 'utf-8');
+
+    it('imports usePreventBrowserZoom', () => {
+      expect(content).toContain('usePreventBrowserZoom');
+    });
+
+    it('imports useZoomPan', () => {
+      expect(content).toContain('useZoomPan');
+    });
+
+    it('imports usePinchZoom', () => {
+      expect(content).toContain('usePinchZoom');
+    });
+
+    it('no longer contains inline gesture prevention effects', () => {
+      // The extracted effects used document.addEventListener('touchmove', ...)
+      // and window.addEventListener('gesturestart', ...) directly.
+      // GalaxyMap should no longer have these — they live in the hooks.
+      expect(content).not.toContain("document.addEventListener('touchmove'");
+      expect(content).not.toContain("window.addEventListener('gesturestart'");
+    });
+
+    it('is under 300 lines', () => {
+      const lineCount = content.split('\n').length;
+      expect(lineCount).toBeLessThan(300);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
GalaxyMapRender was ~500 lines mixing gesture prevention, zoom/pan, touch pinch, and rendering. This PR extracts three focused custom hooks and a shared utility:

- **`usePreventBrowserZoom`** — blocks native browser zoom gestures (document, window, container level), tracks window resize
- **`useZoomPan`** — wheel zoom with throttling and drag-to-pan
- **`usePinchZoom`** — touch pinch-to-zoom with jitter prevention and scale clamping
- **`canvasUtils`** — shared `getDistance` and `requestBatchDraw` helpers

GalaxyMapRender is now ~267 lines focused on rendering and state wiring.

## Tests
- Adds `tests/galaxymap-hooks.test.ts` (20 tests) verifying:
  - Each hook file exists and exports expected functions
  - Shared utility exports
  - GalaxyMap imports and uses all hooks
  - No inline gesture prevention remains in the component
  - Component is under 300 lines

## Test plan
- [ ] Map renders and displays star systems
- [ ] Mouse wheel zoom works
- [ ] Click-drag panning works
- [ ] Touch pinch-to-zoom works on mobile/tablet
- [ ] Browser native zoom is blocked on the canvas
- [ ] Window resize updates stage dimensions

## Disclosure
This PR was AI-generated using Claude Code (Anthropic). A review of the repository found no contribution guidelines, CODE_OF_CONDUCT.md, or any policy explicitly disallowing AI-generated contributions.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)