### PR TITLE
Clean up useFiltering by removing unused exports

### DIFF
--- a/src/components/hooks/useFiltering.ts
+++ b/src/components/hooks/useFiltering.ts
@@ -11,7 +11,7 @@ const useFiltering = () => {
   const { rawSystems, factions, capitals, fetchFactionData, fetchSystemData } =
     useWarmapAPI();
 
-  const { settings, setFlashActive } = useSettings();
+  const { settings } = useSettings();
 
   const projectSystemData = useCallback(
     (rawSystems: StarSystemType[]): DisplayStarSystemType[] => {
@@ -38,13 +38,11 @@ const useFiltering = () => {
 
   return {
     displaySystems,
-    projectSystemData,
     factions,
     capitals,
     fetchFactionData,
     fetchSystemData,
     settings,
-    setFlashActive,
   };
 };
 

--- a/tests/usefiltering.test.ts
+++ b/tests/usefiltering.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const FILTERING_PATH = path.resolve(
+  __dirname,
+  '../src/components/hooks/useFiltering.ts'
+);
+
+describe('useFiltering return shape', () => {
+  const content = fs.readFileSync(FILTERING_PATH, 'utf-8');
+
+  it('returns displaySystems', () => {
+    expect(content).toMatch(/return\s*\{[\s\S]*displaySystems[\s\S]*\}/);
+  });
+
+  it('returns factions', () => {
+    expect(content).toMatch(/return\s*\{[\s\S]*factions[\s\S]*\}/);
+  });
+
+  it('returns capitals', () => {
+    expect(content).toMatch(/return\s*\{[\s\S]*capitals[\s\S]*\}/);
+  });
+
+  it('returns fetchFactionData', () => {
+    expect(content).toMatch(/return\s*\{[\s\S]*fetchFactionData[\s\S]*\}/);
+  });
+
+  it('returns fetchSystemData', () => {
+    expect(content).toMatch(/return\s*\{[\s\S]*fetchSystemData[\s\S]*\}/);
+  });
+
+  it('returns settings', () => {
+    expect(content).toMatch(/return\s*\{[\s\S]*settings[\s\S]*\}/);
+  });
+
+  it('does not expose internal projectSystemData', () => {
+    // projectSystemData is used internally but should not be in the return
+    const returnBlock = content.match(/return\s*\{[\s\S]*?\};/);
+    expect(returnBlock).not.toBeNull();
+    expect(returnBlock![0]).not.toContain('projectSystemData');
+  });
+
+  it('does not expose setFlashActive', () => {
+    const returnBlock = content.match(/return\s*\{[\s\S]*?\};/);
+    expect(returnBlock).not.toBeNull();
+    expect(returnBlock![0]).not.toContain('setFlashActive');
+  });
+});


### PR DESCRIPTION
## Summary
- Removes `projectSystemData` from the return — only used internally within useFiltering's own useEffect
- Removes `setFlashActive` from the return and destructure — unused by any consumer
- Reduces the hook's public surface from 8 to 6 return values

## Tests
- Adds `tests/usefiltering.test.ts` (8 tests) verifying the return shape and guarding against re-exposing internal details

## Disclosure
This PR was AI-generated using Claude Code (Anthropic). A review of the repository found no contribution guidelines, CODE_OF_CONDUCT.md, or any policy explicitly disallowing AI-generated contributions.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)