### PR TITLE
Fix typo: flashActivePlayes → flashActivePlayers

### DIFF
--- a/src/components/hooks/types/Settings.ts
+++ b/src/components/hooks/types/Settings.ts
@@ -1,7 +1,7 @@
 export interface Settings {
-  flashActivePlayes: boolean;
+  flashActivePlayers: boolean;
 }
 
 export const initialSettings: Settings = {
-  flashActivePlayes: true,
+  flashActivePlayers: true,
 };

--- a/src/components/hooks/useSettings.ts
+++ b/src/components/hooks/useSettings.ts
@@ -5,7 +5,7 @@ const useSettings = () => {
   const [settings, setSettingState] = useState<Settings>(initialSettings);
 
   const setFlashActive = (state: boolean) => {
-    setSettingState({ ...settings, flashActivePlayes: state });
+    setSettingState({ ...settings, flashActivePlayers: state });
   };
 
   return {

--- a/src/components/ui/StarSystem.tsx
+++ b/src/components/ui/StarSystem.tsx
@@ -66,7 +66,7 @@ const StarSystem: React.FC<StarSystemProps> = ({
   const circleRef = useRef<Konva.Circle>(null);
 
   useEffect(() => {
-    if (!settings.flashActivePlayes) return;
+    if (!settings.flashActivePlayers) return;
     if (!hasActivePlayers || !circleRef.current) return;
 
     const node = circleRef.current;

--- a/tests/settings-typo.test.ts
+++ b/tests/settings-typo.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SRC_DIR = path.resolve(__dirname, '../src');
+
+function collectFiles(dir: string): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectFiles(full));
+    } else if (/\.(ts|tsx)$/.test(entry.name)) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+describe('no flashActivePlayes typo in src/', () => {
+  const files = collectFiles(SRC_DIR);
+
+  it('flashActivePlayes does not appear anywhere', () => {
+    const violations: string[] = [];
+    for (const file of files) {
+      const content = fs.readFileSync(file, 'utf-8');
+      if (content.includes('flashActivePlayes')) {
+        violations.push(path.relative(SRC_DIR, file));
+      }
+    }
+    expect(violations, `Found typo "flashActivePlayes" in:\n${violations.join('\n')}`).toEqual([]);
+  });
+
+  it('flashActivePlayers exists in Settings.ts', () => {
+    const content = fs.readFileSync(
+      path.resolve(SRC_DIR, 'components/hooks/types/Settings.ts'),
+      'utf-8'
+    );
+    expect(content).toContain('flashActivePlayers');
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes misspelled property `flashActivePlayes` → `flashActivePlayers` across the codebase
- Files changed: `Settings.ts`, `useSettings.ts`, `StarSystem.tsx`

## Tests
- Adds `tests/settings-typo.test.ts` to guard against the typo recurring

## Disclosure
This PR was AI-generated using Claude Code (Anthropic). A review of the repository found no contribution guidelines, CODE_OF_CONDUCT.md, or any policy explicitly disallowing AI-generated contributions.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)