### PR TITLE
Rename component prop types to use Props suffix

### DIFF
--- a/src/components/core/SideMenu.tsx
+++ b/src/components/core/SideMenu.tsx
@@ -2,13 +2,13 @@ import { IconType } from 'react-icons';
 import { FaHome, FaList, FaMap } from 'react-icons/fa';
 import { Link } from 'react-router-dom';
 
-interface MenuItemInterface {
+interface MenuItemProps {
   icon: IconType;
   path: string;
   label: string;
 }
 
-function MenuItem(props: MenuItemInterface) {
+function MenuItem(props: MenuItemProps) {
   return (
     <li className="items-center text-xl text-white font-bold mb-2 rounded hover:bg-gray-500 hover:shadow py-2">
       <Link to={props.path}>

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -13,7 +13,7 @@ enum CardStyle {
   Info = '-info',
 }
 
-export interface HomeCardInterface {
+export interface HomeCardProps {
   style: CardStyle;
   heading: string;
   buttonLabel: string;
@@ -26,7 +26,7 @@ export function HomeCard({
   buttonLabel,
   buttonUri,
   children,
-}: React.PropsWithChildren<HomeCardInterface>) {
+}: React.PropsWithChildren<HomeCardProps>) {
   const borderColor =
     style === CardStyle.Primary ? 'border-primary' : 'border-info';
   const buttonColor =

--- a/src/components/pages/ToS.tsx
+++ b/src/components/pages/ToS.tsx
@@ -1,6 +1,6 @@
 import PageTemplate from '../core/PageTemplate';
 
-interface tosBlockInterface {
+interface TosBlockProps {
   heading2?: string;
   heading3?: string;
 }
@@ -9,7 +9,7 @@ function TosBlock({
   children,
   heading2,
   heading3,
-}: React.PropsWithChildren<tosBlockInterface>) {
+}: React.PropsWithChildren<TosBlockProps>) {
   return (
     <>
       {heading2 && (
@@ -26,13 +26,13 @@ function TosBlock({
     </>
   );
 }
-interface bulletPointInterface {
+interface BulletPointProps {
   isNested?: boolean;
 }
 export function BulletPoint({
   children,
   isNested,
-}: React.PropsWithChildren<bulletPointInterface>) {
+}: React.PropsWithChildren<BulletPointProps>) {
   return (
     <li className={`${isNested ? 'nested-list  ml-12' : 'list-disc ml-4'}`}>
       {children}

--- a/tests/props-naming.test.ts
+++ b/tests/props-naming.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SRC_DIR = path.resolve(__dirname, '../src');
+
+function collectFiles(dir: string): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectFiles(full));
+    } else if (/\.(ts|tsx)$/.test(entry.name)) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+describe('React component prop types use Props suffix, not Interface', () => {
+  const files = collectFiles(SRC_DIR);
+
+  it('no interface declarations ending with "Interface" for component props', () => {
+    const violations: string[] = [];
+    // Match patterns like "interface FooInterface {" or "export interface FooInterface {"
+    const pattern = /interface\s+\w+Interface\s*\{/;
+
+    for (const file of files) {
+      const content = fs.readFileSync(file, 'utf-8');
+      const lines = content.split('\n');
+      lines.forEach((line, i) => {
+        if (pattern.test(line)) {
+          violations.push(`${path.relative(SRC_DIR, file)}:${i + 1}: ${line.trim()}`);
+        }
+      });
+    }
+
+    expect(
+      violations,
+      `Found "Interface" suffix on prop types:\n${violations.join('\n')}`
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Renames `*Interface` prop types to `*Props` with consistent PascalCase per React conventions
- `MenuItemInterface` → `MenuItemProps`, `HomeCardInterface` → `HomeCardProps`
- `tosBlockInterface` → `TosBlockProps`, `bulletPointInterface` → `BulletPointProps`

## Tests
- Adds `tests/props-naming.test.ts` to catch future `Interface`-suffixed prop types

## Disclosure
This PR was AI-generated using Claude Code (Anthropic). A review of the repository found no contribution guidelines, CODE_OF_CONDUCT.md, or any policy explicitly disallowing AI-generated contributions.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)