### PR TITLE
Consolidate icon libraries: migrate react-icons to lucide-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "react": "^18.3.1",
     "react-axios": "^2.0.6",
     "react-dom": "^18.3.1",
-    "react-icons": "^5.3.0",
     "react-konva": "18",
     "react-router-dom": "^6.26.2",
     "react-select": "^5.10.1",

--- a/src/components/core/SideMenu.tsx
+++ b/src/components/core/SideMenu.tsx
@@ -1,18 +1,17 @@
-import { IconType } from 'react-icons';
-import { FaHome, FaList, FaMap } from 'react-icons/fa';
+import { Home, Map, List, type LucideIcon } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
-interface MenuItemInterface {
-  icon: IconType;
+interface MenuItemProps {
+  icon: LucideIcon;
   path: string;
   label: string;
 }
 
-function MenuItem(props: MenuItemInterface) {
+function MenuItem(props: MenuItemProps) {
   return (
     <li className="items-center text-xl text-white font-bold mb-2 rounded hover:bg-gray-500 hover:shadow py-2">
       <Link to={props.path}>
-        {<props.icon className="inline-block w-6 h-6 mr-2 -mt-2" />}
+        <props.icon className="inline-block w-6 h-6 mr-2 -mt-2" />
         {props.label}
       </Link>
     </li>
@@ -30,13 +29,13 @@ export function SideMenu() {
       <br />
       <nav>
         <ul>
-          <MenuItem icon={FaHome} label="Home" path="/" key="Home" />
-          <MenuItem icon={FaMap} label="Map" path="/map" key="Map" />
+          <MenuItem icon={Home} label="Home" path="/" key="Home" />
+          <MenuItem icon={Map} label="Map" path="/map" key="Map" />
         </ul>
       </nav>
       <div className="absolute inset-x-0 bottom-0 h-16 items-center text-2x text-white">
         <Link to="/tos" className="inline-">
-          <FaList className="inline-block w-4 h-4 mr-2 -mt-1" />
+          <List className="inline-block w-4 h-4 mr-2 -mt-1" />
           Terms of Data Use
         </Link>
       </div>

--- a/src/components/pages/Error.tsx
+++ b/src/components/pages/Error.tsx
@@ -1,4 +1,4 @@
-import { HiHome } from 'react-icons/hi';
+import { Home } from 'lucide-react';
 import { useRouteError, isRouteErrorResponse, Link } from 'react-router-dom';
 import PageTemplate from '../core/PageTemplate';
 
@@ -27,7 +27,7 @@ function ErrorPageContent() {
         Discord Server
         <Link to={'/'}>
           <div className="flex">
-            <HiHome className="inline-block w-6 h-6 mr-2 -mt-2" />
+            <Home className="inline-block w-6 h-6 mr-2 -mt-2" />
             Click here to return Home
           </div>
         </Link>

--- a/tests/no-react-icons.test.ts
+++ b/tests/no-react-icons.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SRC_DIR = path.resolve(__dirname, '../src');
+
+function collectFiles(dir: string): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectFiles(full));
+    } else if (/\.(ts|tsx)$/.test(entry.name)) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+describe('react-icons is fully replaced by lucide-react', () => {
+  const files = collectFiles(SRC_DIR);
+
+  it('no imports from react-icons in src/', () => {
+    const violations: string[] = [];
+    for (const file of files) {
+      const content = fs.readFileSync(file, 'utf-8');
+      if (/from\s+['"]react-icons/.test(content)) {
+        violations.push(path.relative(SRC_DIR, file));
+      }
+    }
+    expect(violations, `Found react-icons imports in:\n${violations.join('\n')}`).toEqual([]);
+  });
+
+  it('react-icons is not in package.json dependencies', () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8')
+    );
+    expect(packageJson.dependencies).not.toHaveProperty('react-icons');
+  });
+});


### PR DESCRIPTION
## Summary
- Migrates all `react-icons` usage to `lucide-react` equivalents
- `FaHome` → `Home`, `FaMap` → `Map`, `FaList` → `List` (SideMenu.tsx)
- `HiHome` → `Home` (Error.tsx)
- `IconType` → `LucideIcon` type
- Removes `react-icons` from `package.json`
- Reduces bundle by eliminating a redundant icon library

## Tests
- Adds `tests/no-react-icons.test.ts` to prevent react-icons re-introduction

## Test plan
- [ ] SideMenu icons render correctly (Home, Map, ToS list)
- [ ] Error page home icon renders

## Disclosure
This PR was AI-generated using Claude Code (Anthropic). A review of the repository found no contribution guidelines, CODE_OF_CONDUCT.md, or any policy explicitly disallowing AI-generated contributions.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)