### PR TITLE
Remove commented-out code from App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,28 +5,20 @@ import {
   RouterProvider,
 } from 'react-router-dom';
 import { Map } from './components/pages/';
-// import { Home, Map } from './components/pages/';
 import ErrorPage from './components/pages/Error';
 import { BASE_ROUTE } from './components/helpers/RouteHelper.ts';
-// import { ToS } from './components/pages/ToS';
 
 const router = createBrowserRouter(
   createRoutesFromElements(
     <>
       <Route path="/" element={<Map />} errorElement={<ErrorPage />} />
-
       <Route index element={<Map />} />
-      {/* <Route path="/map" element={<Map />} /> */}
-      {/* <Route path="/tos" element={<ToS />} /> */}
     </>
   ), {basename: BASE_ROUTE}
 );
 
 export default function App() {
   return (
-    <RouterProvider
-      router={router}
-      // fallbackElement={<Fallback /> }
-    />
+    <RouterProvider router={router} />
   );
 }

--- a/tests/no-dead-code-app.test.ts
+++ b/tests/no-dead-code-app.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('App.tsx has no commented-out code', () => {
+  const content = fs.readFileSync(
+    path.resolve(__dirname, '../src/App.tsx'),
+    'utf-8'
+  );
+
+  it('no commented-out imports', () => {
+    expect(content).not.toMatch(/\/\/\s*import\s/);
+  });
+
+  it('no commented-out JSX routes', () => {
+    expect(content).not.toMatch(/\{\/\*.*<Route/);
+  });
+
+  it('no commented-out props', () => {
+    expect(content).not.toMatch(/\/\/\s*fallbackElement/);
+  });
+});


### PR DESCRIPTION
## Summary
- Removes commented imports (Home, ToS), unused route definitions (/map, /tos), and commented fallbackElement prop

## Tests
- Adds `tests/no-dead-code-app.test.ts`

## Disclosure
This PR was AI-generated using Claude Code (Anthropic). No policy was found disallowing AI-generated contributions.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)