### PR TITLE
Make FactionType.capital optional

### DIFF
--- a/src/components/hooks/types/FactionType.ts
+++ b/src/components/hooks/types/FactionType.ts
@@ -2,5 +2,5 @@ export type FactionType = {
   colour: string;
   prettyName: string;
   id: number;
-  capital: string;
+  capital?: string;
 };

--- a/tests/faction-type.test.ts
+++ b/tests/faction-type.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import type { FactionType } from '../src/components/hooks/types';
+
+describe('FactionType', () => {
+  it('capital is optional', () => {
+    // A faction without a capital should be valid
+    const faction: FactionType = {
+      colour: 'red',
+      prettyName: 'Test',
+      id: 1,
+    };
+    expectTypeOf(faction.capital).toEqualTypeOf<string | undefined>();
+  });
+});


### PR DESCRIPTION
## Summary
- Changes `capital: string` to `capital?: string` in FactionType — not all factions have capitals
- Runtime already guards with a truthy check in useWarmapAPI.ts

## Tests
- Adds `tests/faction-type.test.ts` with type-level verification

## Disclosure
This PR was AI-generated using Claude Code (Anthropic). No policy was found disallowing AI-generated contributions.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)