### PR TITLE
Add runtime validation for API responses

### DIFF
--- a/src/components/hooks/useWarmapAPI.ts
+++ b/src/components/hooks/useWarmapAPI.ts
@@ -14,6 +14,14 @@ const useWarmapAPI = () => {
         `${API_BASE_URL}/api/v1/factions/warmap`
       ).then((res) => res.json());
 
+      if (
+        !factionData ||
+        typeof factionData !== 'object' ||
+        Array.isArray(factionData)
+      ) {
+        throw new Error('Faction API returned unexpected data shape');
+      }
+
       factionData['NoFaction'] = {
         colour: 'gray',
         prettyName: 'Unaffiliated',
@@ -39,6 +47,10 @@ const useWarmapAPI = () => {
       const systemData = await fetch(
         `${API_BASE_URL}/api/v1/starmap/warmap`
       ).then((res) => res.json());
+
+      if (!Array.isArray(systemData)) {
+        throw new Error('System API returned unexpected data shape');
+      }
 
       setRawSystems(systemData);
     } catch (error) {

--- a/tests/api-validation.test.ts
+++ b/tests/api-validation.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('API response validation in useWarmapAPI', () => {
+  const content = fs.readFileSync(
+    path.resolve(__dirname, '../src/components/hooks/useWarmapAPI.ts'),
+    'utf-8'
+  );
+
+  it('validates faction data is a non-null object', () => {
+    expect(content).toContain("typeof factionData !== 'object'");
+    expect(content).toContain('Array.isArray(factionData)');
+  });
+
+  it('validates system data is an array', () => {
+    expect(content).toContain('Array.isArray(systemData)');
+  });
+
+  it('throws descriptive errors on invalid shapes', () => {
+    expect(content).toContain('Faction API returned unexpected data shape');
+    expect(content).toContain('System API returned unexpected data shape');
+  });
+});


### PR DESCRIPTION
## Summary
- Validates faction API returns a non-null object (not array)
- Validates system API returns an array
- Throws descriptive errors on unexpected shapes instead of silently corrupting state

## Tests
- Adds `tests/api-validation.test.ts`

## Disclosure
This PR was AI-generated using Claude Code (Anthropic). No policy was found disallowing AI-generated contributions.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)