### PR TITLE
Extract SearchInput and FactionSelector from BottomFilterPanel

### DIFF
--- a/src/components/ui/BottomFilterPanel.tsx
+++ b/src/components/ui/BottomFilterPanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
-import Select, { MultiValue } from 'react-select';
 import { ChevronsUp, ChevronsDown } from 'lucide-react';
+import SearchInput from './SearchInput';
+import FactionSelector from './FactionSelector';
 
 const BottomFilterPanel = ({
   searchTerm,
@@ -27,22 +28,8 @@ const BottomFilterPanel = ({
     return () => window.removeEventListener('resize', onResize);
   }, []);
 
-  /* react-select helpers */
-  const options = factions.map((f) => ({ value: f, label: f }));
-  const selectedOpts = options.filter((o) =>
-    selectedFactions.includes(o.value)
-  );
-  const onFactionChange = (
-    vals: MultiValue<{ value: string; label: string }>
-  ) => setSelectedFactions(vals.map((v) => v.value));
-
-  const removeFaction = (name: string) =>
-    setSelectedFactions(selectedFactions.filter((f) => f !== name));
-
   const panelRef = useRef<HTMLDivElement>(null);
   const [height, setHeight] = useState<string>('32px');
-
-  const [showTooltip, setShowTooltip] = useState(false);
 
   useEffect(() => {
     const panel = panelRef.current;
@@ -69,23 +56,6 @@ const BottomFilterPanel = ({
       });
     });
   }, [isOpen, selectedFactions]);
-
-  const tooltipStyle: React.CSSProperties = {
-    position: 'absolute',
-    backgroundColor: '#333',
-    color: '#fff',
-    padding: '6px 10px',
-    borderRadius: '4px',
-    fontSize: '12px',
-    whiteSpace: 'normal',
-    width: 'max-content',
-    display: 'inline-block',
-    maxWidth: isDesktop ? '220px' : '90vw',
-    zIndex: 10000,
-    ...(isDesktop
-      ? { bottom: 22, left: 0 } // desktop: below/right of icon
-      : { bottom: 28, right: 8, left: 'auto', transform: 'none' }), // mobile: centered below icon
-  };
 
   return (
     <div
@@ -131,137 +101,17 @@ const BottomFilterPanel = ({
             height: '100%',
           }}
         >
-          {/* LEFT column — system search */}
-          <div style={{ flex: 1, paddingRight: '0.75rem' }}>
-            <input
-              type="text"
-              placeholder="Search systems…"
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              style={{
-                width: isDesktop ? '50%' : '100%', // ← half width on desktop
-                padding: '6px 10px',
-                fontSize: '16px',
-                borderRadius: '6px',
-                border: '1px solid #ccc',
-                outline: 'none',
-                backgroundColor: 'white',
-                color: 'black',
-                margin: '0 0.25rem 0.5rem', // side + bottom space
-              }}
-            />
-          </div>
-
-          {/* RIGHT column — faction select */}
-          <div
-            style={{
-              flex: 1,
-              paddingLeft: '0.75rem',
-              borderLeft: '1px solid #555',
-            }}
-          >
-            <div style={{ width: isDesktop ? '50%' : '100%' }}>
-              <div
-                style={{ display: 'flex', alignItems: 'center', gap: '8px' }}
-              >
-                <div style={{ flexGrow: 1 }}>
-                  <Select
-                    isMulti
-                    options={options}
-                    value={selectedOpts}
-                    onChange={onFactionChange}
-                    menuPortalTarget={document.body}
-                    menuPlacement="top"
-                    placeholder="Filter factions…"
-                    components={{ MultiValue: () => null }}
-                    styles={{
-                      control: (base) => ({
-                        ...base,
-                        color: 'black',
-                        width: '100%',
-                      }),
-                      input: (base) => ({ ...base, color: 'black' }),
-                      singleValue: (base) => ({ ...base, color: 'black' }),
-                      multiValueLabel: (base) => ({ ...base, color: 'black' }),
-                      option: (base, state) => ({
-                        ...base,
-                        color: 'black',
-                        backgroundColor: state.isFocused ? '#e6e6e6' : 'white',
-                      }),
-                      menuPortal: (base) => ({ ...base, zIndex: 9999 }),
-                    }}
-                  />
-                </div>
-
-                <div
-                  style={{
-                    position: 'relative',
-                    display: 'inline-block',
-                    cursor: 'pointer',
-                    width: '18px',
-                    height: '18px',
-                    borderRadius: '50%',
-                    backgroundColor: '#888',
-                    color: 'white',
-                    fontSize: '12px',
-                    textAlign: 'center',
-                    lineHeight: '18px',
-                  }}
-                  onMouseEnter={() => isDesktop && setShowTooltip(true)}
-                  onMouseLeave={() => isDesktop && setShowTooltip(false)}
-                  onClick={() => !isDesktop && setShowTooltip((prev) => !prev)}
-                >
-                  i
-                  {showTooltip && (
-                    <div style={tooltipStyle}>
-                      Only factions that currently have systems on the map will
-                      appear here.
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              {/* chosen factions shown under the search bar */}
-              {selectedFactions.length > 0 && (
-                <div
-                  style={{
-                    marginTop: '0.5rem',
-                    display: 'flex',
-                    flexWrap: 'wrap',
-                    gap: '4px',
-                  }}
-                >
-                  {selectedFactions.map((f) => (
-                    <span
-                      key={f}
-                      style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        color: 'white',
-                        fontSize: '14px',
-                        background: 'rgba(255,255,255,0.15)',
-                        padding: '2px 6px',
-                        borderRadius: '4px',
-                      }}
-                    >
-                      {f}
-                      <span
-                        onClick={() => removeFaction(f)}
-                        style={{
-                          marginLeft: '4px',
-                          cursor: 'pointer',
-                          fontWeight: 'bold',
-                          lineHeight: 1,
-                        }}
-                      >
-                        x
-                      </span>
-                    </span>
-                  ))}
-                </div>
-              )}
-            </div>
-          </div>
+          <SearchInput
+            searchTerm={searchTerm}
+            setSearchTerm={setSearchTerm}
+            isDesktop={isDesktop}
+          />
+          <FactionSelector
+            factions={factions}
+            selectedFactions={selectedFactions}
+            setSelectedFactions={setSelectedFactions}
+            isDesktop={isDesktop}
+          />
         </div>
       )}
     </div>

--- a/src/components/ui/FactionSelector.tsx
+++ b/src/components/ui/FactionSelector.tsx
@@ -1,0 +1,159 @@
+import { useState } from 'react';
+import Select, { MultiValue } from 'react-select';
+
+interface FactionSelectorProps {
+  factions: string[];
+  selectedFactions: string[];
+  setSelectedFactions: (v: string[]) => void;
+  isDesktop: boolean;
+}
+
+const FactionSelector = ({
+  factions,
+  selectedFactions,
+  setSelectedFactions,
+  isDesktop,
+}: FactionSelectorProps) => {
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  const options = factions.map((f) => ({ value: f, label: f }));
+  const selectedOpts = options.filter((o) =>
+    selectedFactions.includes(o.value)
+  );
+  const onFactionChange = (
+    vals: MultiValue<{ value: string; label: string }>
+  ) => setSelectedFactions(vals.map((v) => v.value));
+
+  const removeFaction = (name: string) =>
+    setSelectedFactions(selectedFactions.filter((f) => f !== name));
+
+  const tooltipStyle: React.CSSProperties = {
+    position: 'absolute',
+    backgroundColor: '#333',
+    color: '#fff',
+    padding: '6px 10px',
+    borderRadius: '4px',
+    fontSize: '12px',
+    whiteSpace: 'normal',
+    width: 'max-content',
+    display: 'inline-block',
+    maxWidth: isDesktop ? '220px' : '90vw',
+    zIndex: 10000,
+    ...(isDesktop
+      ? { bottom: 22, left: 0 }
+      : { bottom: 28, right: 8, left: 'auto', transform: 'none' }),
+  };
+
+  return (
+    <div
+      style={{
+        flex: 1,
+        paddingLeft: '0.75rem',
+        borderLeft: '1px solid #555',
+      }}
+    >
+      <div style={{ width: isDesktop ? '50%' : '100%' }}>
+        <div
+          style={{ display: 'flex', alignItems: 'center', gap: '8px' }}
+        >
+          <div style={{ flexGrow: 1 }}>
+            <Select
+              isMulti
+              options={options}
+              value={selectedOpts}
+              onChange={onFactionChange}
+              menuPortalTarget={document.body}
+              menuPlacement="top"
+              placeholder="Filter factions…"
+              components={{ MultiValue: () => null }}
+              styles={{
+                control: (base) => ({
+                  ...base,
+                  color: 'black',
+                  width: '100%',
+                }),
+                input: (base) => ({ ...base, color: 'black' }),
+                singleValue: (base) => ({ ...base, color: 'black' }),
+                multiValueLabel: (base) => ({ ...base, color: 'black' }),
+                option: (base, state) => ({
+                  ...base,
+                  color: 'black',
+                  backgroundColor: state.isFocused ? '#e6e6e6' : 'white',
+                }),
+                menuPortal: (base) => ({ ...base, zIndex: 9999 }),
+              }}
+            />
+          </div>
+
+          <div
+            style={{
+              position: 'relative',
+              display: 'inline-block',
+              cursor: 'pointer',
+              width: '18px',
+              height: '18px',
+              borderRadius: '50%',
+              backgroundColor: '#888',
+              color: 'white',
+              fontSize: '12px',
+              textAlign: 'center',
+              lineHeight: '18px',
+            }}
+            onMouseEnter={() => isDesktop && setShowTooltip(true)}
+            onMouseLeave={() => isDesktop && setShowTooltip(false)}
+            onClick={() => !isDesktop && setShowTooltip((prev) => !prev)}
+          >
+            i
+            {showTooltip && (
+              <div style={tooltipStyle}>
+                Only factions that currently have systems on the map will
+                appear here.
+              </div>
+            )}
+          </div>
+        </div>
+
+        {selectedFactions.length > 0 && (
+          <div
+            style={{
+              marginTop: '0.5rem',
+              display: 'flex',
+              flexWrap: 'wrap',
+              gap: '4px',
+            }}
+          >
+            {selectedFactions.map((f) => (
+              <span
+                key={f}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  color: 'white',
+                  fontSize: '14px',
+                  background: 'rgba(255,255,255,0.15)',
+                  padding: '2px 6px',
+                  borderRadius: '4px',
+                }}
+              >
+                {f}
+                <span
+                  onClick={() => removeFaction(f)}
+                  style={{
+                    marginLeft: '4px',
+                    cursor: 'pointer',
+                    fontWeight: 'bold',
+                    lineHeight: 1,
+                  }}
+                >
+                  x
+                </span>
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default FactionSelector;

--- a/src/components/ui/SearchInput.tsx
+++ b/src/components/ui/SearchInput.tsx
@@ -1,0 +1,31 @@
+interface SearchInputProps {
+  searchTerm: string;
+  setSearchTerm: (term: string) => void;
+  isDesktop: boolean;
+}
+
+const SearchInput = ({ searchTerm, setSearchTerm, isDesktop }: SearchInputProps) => {
+  return (
+    <div style={{ flex: 1, paddingRight: '0.75rem' }}>
+      <input
+        type="text"
+        placeholder="Search systems…"
+        value={searchTerm}
+        onChange={(e) => setSearchTerm(e.target.value)}
+        style={{
+          width: isDesktop ? '50%' : '100%',
+          padding: '6px 10px',
+          fontSize: '16px',
+          borderRadius: '6px',
+          border: '1px solid #ccc',
+          outline: 'none',
+          backgroundColor: 'white',
+          color: 'black',
+          margin: '0 0.25rem 0.5rem',
+        }}
+      />
+    </div>
+  );
+};
+
+export default SearchInput;

--- a/tests/bottomfilterpanel-subcomponents.test.ts
+++ b/tests/bottomfilterpanel-subcomponents.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const UI_DIR = path.resolve(__dirname, '../src/components/ui');
+
+describe('BottomFilterPanel subcomponents', () => {
+  it('SearchInput.tsx exists', () => {
+    expect(fs.existsSync(path.join(UI_DIR, 'SearchInput.tsx'))).toBe(true);
+  });
+
+  it('FactionSelector.tsx exists', () => {
+    expect(fs.existsSync(path.join(UI_DIR, 'FactionSelector.tsx'))).toBe(true);
+  });
+
+  it('BottomFilterPanel imports SearchInput', () => {
+    const content = fs.readFileSync(
+      path.join(UI_DIR, 'BottomFilterPanel.tsx'),
+      'utf-8'
+    );
+    expect(content).toContain("from './SearchInput'");
+  });
+
+  it('BottomFilterPanel imports FactionSelector', () => {
+    const content = fs.readFileSync(
+      path.join(UI_DIR, 'BottomFilterPanel.tsx'),
+      'utf-8'
+    );
+    expect(content).toContain("from './FactionSelector'");
+  });
+
+  it('BottomFilterPanel no longer contains react-select import', () => {
+    const content = fs.readFileSync(
+      path.join(UI_DIR, 'BottomFilterPanel.tsx'),
+      'utf-8'
+    );
+    expect(content).not.toContain('react-select');
+  });
+
+  it('BottomFilterPanel is under 130 lines', () => {
+    const content = fs.readFileSync(
+      path.join(UI_DIR, 'BottomFilterPanel.tsx'),
+      'utf-8'
+    );
+    expect(content.split('\n').length).toBeLessThan(130);
+  });
+});


### PR DESCRIPTION
## Summary
- Extracts `SearchInput` component (text input with responsive width)
- Extracts `FactionSelector` component (react-select dropdown, info tooltip, faction chips)
- BottomFilterPanel reduced from 271 to ~115 lines, focused on panel animation and layout

## Tests
- Adds `tests/bottomfilterpanel-subcomponents.test.ts` (6 tests)

## Test plan
- [ ] Search input filters star systems
- [ ] Faction dropdown works with multi-select
- [ ] Faction chips display and can be removed
- [ ] Info tooltip shows on hover (desktop) and tap (mobile)
- [ ] Panel expand/collapse animation works

## Disclosure
This PR was AI-generated using Claude Code (Anthropic). No policy was found disallowing AI-generated contributions.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)