### PR TITLE
PR B: Fix SideMenu, rename props, migrate icons, fix Home class

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "react": "^18.3.1",
     "react-axios": "^2.0.6",
     "react-dom": "^18.3.1",
-    "react-icons": "^5.3.0",
     "react-konva": "18",
     "react-router-dom": "^6.26.2",
     "react-select": "^5.10.1",

--- a/src/components/core/SideMenu.tsx
+++ b/src/components/core/SideMenu.tsx
@@ -1,18 +1,17 @@
-import { IconType } from 'react-icons';
-import { FaHome, FaList, FaMap } from 'react-icons/fa';
+import { Home, Map, List, type LucideIcon } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
-interface MenuItemInterface {
-  icon: IconType;
+interface MenuItemProps {
+  icon: LucideIcon;
   path: string;
   label: string;
 }
 
-function MenuItem(props: MenuItemInterface) {
+function MenuItem(props: MenuItemProps) {
   return (
     <li className="items-center text-xl text-white font-bold mb-2 rounded hover:bg-gray-500 hover:shadow py-2">
       <Link to={props.path}>
-        {<props.icon className="inline-block w-6 h-6 mr-2 -mt-2" />}
+        <props.icon className="inline-block w-6 h-6 mr-2 -mt-2" />
         {props.label}
       </Link>
     </li>
@@ -30,13 +29,13 @@ export function SideMenu() {
       <br />
       <nav>
         <ul>
-          <MenuItem icon={FaHome} label="Home" path="/" key="Home" />
-          <MenuItem icon={FaMap} label="Map" path="/map" key="Map" />
+          <MenuItem icon={Home} label="Home" path="/" key="Home" />
+          <MenuItem icon={Map} label="Map" path="/map" key="Map" />
         </ul>
       </nav>
-      <div className="absolute inset-x-0 bottom-0 h-16 items-center text-2x text-white">
+      <div className="absolute inset-x-0 bottom-0 h-16 items-center text-2xl text-white">
         <Link to="/tos" className="inline-">
-          <FaList className="inline-block w-4 h-4 mr-2 -mt-1" />
+          <List className="inline-block w-4 h-4 mr-2 -mt-1" />
           Terms of Data Use
         </Link>
       </div>

--- a/src/components/pages/Error.tsx
+++ b/src/components/pages/Error.tsx
@@ -1,4 +1,4 @@
-import { HiHome } from 'react-icons/hi';
+import { Home } from 'lucide-react';
 import { useRouteError, isRouteErrorResponse, Link } from 'react-router-dom';
 import PageTemplate from '../core/PageTemplate';
 
@@ -27,7 +27,7 @@ function ErrorPageContent() {
         Discord Server
         <Link to={'/'}>
           <div className="flex">
-            <HiHome className="inline-block w-6 h-6 mr-2 -mt-2" />
+            <Home className="inline-block w-6 h-6 mr-2 -mt-2" />
             Click here to return Home
           </div>
         </Link>

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -13,7 +13,7 @@ enum CardStyle {
   Info = '-info',
 }
 
-export interface HomeCardInterface {
+export interface HomeCardProps {
   style: CardStyle;
   heading: string;
   buttonLabel: string;
@@ -26,7 +26,7 @@ export function HomeCard({
   buttonLabel,
   buttonUri,
   children,
-}: React.PropsWithChildren<HomeCardInterface>) {
+}: React.PropsWithChildren<HomeCardProps>) {
   const borderColor =
     style === CardStyle.Primary ? 'border-primary' : 'border-info';
   const buttonColor =
@@ -35,7 +35,7 @@ export function HomeCard({
 
   return (
     <Card
-      className={`mt-6 w-96 h-56 border-2 ${borderColor} p-5 rounded-lg ml-14 inline-block h-96 relative grow-0`}
+      className={`mt-6 w-96 border-2 ${borderColor} p-5 rounded-lg ml-14 inline-block h-96 relative grow-0`}
     >
       <CardHeader className={`relative font-bold ${textColor}`}>
         {heading}

--- a/src/components/pages/ToS.tsx
+++ b/src/components/pages/ToS.tsx
@@ -1,6 +1,6 @@
 import PageTemplate from '../core/PageTemplate';
 
-interface tosBlockInterface {
+interface TosBlockProps {
   heading2?: string;
   heading3?: string;
 }
@@ -9,7 +9,7 @@ function TosBlock({
   children,
   heading2,
   heading3,
-}: React.PropsWithChildren<tosBlockInterface>) {
+}: React.PropsWithChildren<TosBlockProps>) {
   return (
     <>
       {heading2 && (
@@ -26,13 +26,13 @@ function TosBlock({
     </>
   );
 }
-interface bulletPointInterface {
+interface BulletPointProps {
   isNested?: boolean;
 }
 export function BulletPoint({
   children,
   isNested,
-}: React.PropsWithChildren<bulletPointInterface>) {
+}: React.PropsWithChildren<BulletPointProps>) {
   return (
     <li className={`${isNested ? 'nested-list  ml-12' : 'list-disc ml-4'}`}>
       {children}


### PR DESCRIPTION
## Summary
- Fix text-2x → text-2xl in SideMenu
- Migrate react-icons → lucide-react, remove react-icons dep
- Rename *Interface → *Props with PascalCase (SideMenu, Home, ToS)
- Remove conflicting h-56 class from HomeCard

**Merge order: 3 of 7** — independent of PR A.

Replaces: #11, #12, #19, #20

## Disclosure
This PR was AI-generated using Claude Code (Anthropic). No policy was found disallowing AI-generated contributions.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)