### PR TITLE
fix + perf: bug fixes, tests, and React reconciliation improvements

### DIFF
--- a/src/components/pages/GalaxyMap.tsx
+++ b/src/components/pages/GalaxyMap.tsx
@@ -118,7 +118,6 @@ const GalaxyMapRender = ({
     scaleRef,
     positionRef,
     view,
-    zoomScaleFactor,
     requestBatchDraw,
     setZoomScaleFactor,
     handlers: { onWheel, onDragMove },

--- a/src/components/ui/StarSystem.tsx
+++ b/src/components/ui/StarSystem.tsx
@@ -204,7 +204,7 @@ const StarSystem: React.FC<StarSystemProps> = ({
     }, group.getLayer());
 
     animation.start();
-    return () => animation.stop();
+    return () => { animation.stop(); };
   }, [scaleRef]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- **Pinch zoom**: call `setZoomScaleFactor` during active pinch gesture so star dots resize mid-gesture instead of snapping at lift
- **Mobile tooltip**: replace broken `inControlBlock` state machine with prefix-based filter (`Owner:`, `Damage:`, `State:`) so faction control data is no longer silently dropped
- **Animation restart glitch**: read icon Konva nodes from refs each frame instead of capturing at effect setup time, preventing mid-animation restarts when icons load
- **SSR/window guard**: add `typeof window !== 'undefined'` guards to `positionRef` initialisation in `useGalaxyViewport`
- **Stale closure**: wrap `getDesktopLineSegments` in `useCallback` with explicit font-size deps; update `desktopTooltipLayout` memo deps accordingly
- **Typo**: rename `flashActivePlayes` → `flashActivePlayers` across types, hook, and usage
- **Icon loader factory**: replace three near-identical loader functions + 6 module-level cache vars with a `makeIconLoader(url)` factory (105 lines → 32)
- **Tests**: 44 new tests covering `devStateInjector`, and the pure math in `useTooltip`, `useGalaxyViewport`, and `usePinchZoom`

### Performance (React reconciliation)

- **Stable React key**: pre-compute `system.id` (`name+posX+posY`) in `projectSystemData` so the key is built once at data load rather than per-visible-system per pan frame (13× faster key construction). Removing `owner` from the key means faction captures flow as prop updates rather than unmount+remount, preserving animation state.
- **Eliminate zoom re-renders**: replace `zoomScaleFactor` prop on `StarSystem` with `scaleRef` (stable ref). `memo()` now correctly short-circuits during zoom — previously all 800+ visible components re-rendered on every wheel tick when zoomed out. Dot sizing is now handled by a single `Konva.Animation` per system that imperatively updates `group.scale` each RAF frame, matching the pattern already used for stage pan/zoom.
- **Benchmark suite**: `tests/perf.bench.ts` covers all hot paths with before/after variants; run with `yarn bench`.

## Test plan

- [ ] Pan and zoom the map — dots should remain at constant screen size, no jank during zoom-out
- [ ] Pinch zoom on mobile — dots resize mid-gesture
- [ ] Tap a system on mobile — tooltip shows Owner, Damage, State lines correctly
- [ ] Systems with pirate/HTL/capture events — pulse animation runs without restart glitch
- [ ] Search for a system name — opacity filter works
- [ ] Faction filter — correct systems highlighted
- [ ] `yarn vitest run` — 68 tests pass
- [ ] `yarn bench` — benchmark suite runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)