### PR TITLE
fix + perf + build: bug fixes, reconciliation improvements, chunk splitting

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "build:test": "tsc -b && cross-env VITE_ENABLE_STATE_TEST=true vite build",
     "lint": "eslint .",
     "preview": "vite preview"
   },
@@ -33,6 +34,7 @@
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react-swc": "^3.5.0",
     "autoprefixer": "^10.4.20",
+    "cross-env": "^10.1.0",
     "eslint": "^9.9.0",
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.9",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "build:test": "tsc -b && cross-env VITE_ENABLE_STATE_TEST=true vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "bench": "vitest bench"
   },
   "dependencies": {
     "@material-tailwind/react": "^2.1.10",

--- a/review.md
+++ b/review.md
@@ -1,0 +1,149 @@
+# Code Review: `system-state` branch
+
+## Overview
+
+This branch has two major feature areas and significant structural refactoring:
+
+1. **System state visualization** — new `StarSystemState` type carrying insurrection, pirate raid, capture event, and hold-the-line flags, with per-system graphical effects (glow rings, animated pulses, icon overlays)
+2. **Viewport architecture overhaul** — zoom/pan extracted into `useGalaxyViewport`, pinch-to-zoom into `usePinchZoom`, mobile tooltip moved from Konva canvas into DOM, viewport culling added, desktop tooltip rebuilt with canvas text measurement
+
+Supporting work: `devStateInjector.ts` for dev testing, new unit tests, `normalizedName` field, `useDeferredValue` for search.
+
+---
+
+## Positive highlights
+
+- **Hook extraction is clean.** `useGalaxyViewport` and `usePinchZoom` are focused and well-typed. The shared ref pattern (`scaleRef`, `positionRef`) correctly avoids stale-closure issues while keeping the Konva interaction path off the React render cycle.
+- **Viewport culling (`visibleSystems`)** is the right move. Filtering to only render on-screen systems before passing to Konva is a substantial win for large maps.
+- **`useDeferredValue` for search** is a correct React 18 pattern — low-priority updates won't block the map interaction.
+- **`normalizedName` computed once at the data layer** is better than calling `.toLowerCase()` inside every filter pass.
+- **Mobile tooltip in DOM** (rather than a Konva `Label`) is the right call: proper text reflow, scroll for long content, accessible.
+- **`devStateInjector`** is well-gated (`import.meta.env.DEV`), supports multiple presets, localStorage overrides, and won't reach production.
+- **Background image error handling** (`bgLoadError`) and `stage.container` type guard are good defensive additions.
+
+---
+
+## Issues and suggestions
+
+### Bugs / correctness
+
+**1. `setZoomScaleFactor` missing from `usePinchZoom.onTouchMove` — scale factor not updated during pinch**
+
+`onTouchMove` updates `scaleRef.current` and the Konva stage directly but never calls `setZoomScaleFactor`, so `zoomScaleFactor` stays stale during the pinch gesture. The `zoomScaleFactor` drives system dot sizing, so stars won't resize mid-pinch. The call only happens in `onTouchEnd`. Additionally, `setZoomScaleFactor` is listed in the `onTouchMove` dep array but never actually called there.
+
+```ts
+// usePinchZoom.ts — inside the rAF callback in onTouchMove, add:
+setZoomScaleFactor(newScale);
+```
+
+**2. `useGalaxyViewport` accesses `window` at init time with no guard**
+
+```ts
+const positionRef = useRef<Point>({
+  x: window.innerWidth / 2,  // line ~27 — crashes in SSR / test environments
+  y: window.innerHeight / 2,
+});
+```
+
+The rest of the file guards all `window` access, but this initializer runs unconditionally. Pair with the `getViewportSize()` helper already defined in `GalaxyMap.tsx`:
+
+```ts
+const initialSize = typeof window !== 'undefined'
+  ? { x: window.innerWidth / 2, y: window.innerHeight / 2 }
+  : { x: 0, y: 0 };
+const positionRef = useRef<Point>(initialSize);
+```
+
+**3. `desktopTooltipLayout` useMemo has a stale closure on `getDesktopLineSegments`**
+
+`getDesktopLineSegments` is defined inside the component and captures `desktopTitleFontSize` / `desktopBodyFontSize`. The useMemo lists `desktopTooltipLines` and `desktopLineHeight` as deps but not `getDesktopLineSegments`:
+
+```ts
+const desktopTooltipLayout = useMemo(() => {
+  // calls getDesktopLineSegments(line, index) ...
+}, [desktopTooltipLines, tooltipFontSize, desktopLineHeight]); // missing getDesktopLineSegments
+```
+
+Currently safe because font sizes aren't React state — but this will silently break if that changes. Either add `getDesktopLineSegments` to deps or extract it with `useCallback`.
+
+**4. Insurrection animation restarts when icon images load**
+
+`shouldPulseSize` effect depends on `[shouldPulseSize, pirateIconImage, holdTheLineIconImage, captureEventIconImage]`. When an image loads (triggering a re-render via `setState`), the animation stops mid-frame and restarts. The stopped frame leaves nodes at an intermediate animation state for one tick, causing a brief visual glitch. Consider tracking loaded images in a ref and only including the boolean flags in the animation effect deps.
+
+---
+
+### Performance concerns
+
+**5. `visibleSystems` recomputes on every drag tick**
+
+`visibleSystems` depends on `view`, which updates via `schedulePositionUpdate` (one rAF delay after each drag event). That's fine. However, `getViewportBounds` is defined inside the component body but outside `useMemo` — a new function reference every render. This doesn't cause a stale closure problem here, but it's unnecessary noise. Extract it to module scope (it has no component-level deps).
+
+**6. `renderedSystems` key includes coordinates — ownership change forces full remount**
+
+```tsx
+key={`${system.name}-${system.posX}-${system.posY}-${system.owner}`}
+```
+
+Coordinates are effectively fixed per system, so including them is harmless. But the key also means that a faction ownership change forces a full unmount/remount of the `StarSystem` node, restarting all its Konva animations. If smoothly transitioning ownership changes ever matters, you'd want the key to be just `system.name`.
+
+**7. Three near-identical icon loaders in `StarSystem.tsx`**
+
+`loadPirateIconImage`, `loadHoldTheLineIconImage`, `loadCaptureEventIconImage` are identical modulo the URL and cache vars. A single generic factory reduces future maintenance burden:
+
+```ts
+const makeIconLoader = (url: string) => {
+  let cache: HTMLImageElement | null = null;
+  let promise: Promise<HTMLImageElement> | null = null;
+  return () => { /* shared logic */ };
+};
+```
+
+---
+
+### Code quality / style
+
+**8. `mobileTooltipData` parsing is fragile string-splitting on API text**
+
+The memo parses the tooltip text string (which was originally built in `buildTooltipText`) by splitting on `\n` and pattern-matching for `Control:`, `Owner:`, etc. This means two representations of the same data exist: the structured `controlItems` array already present on `tooltip`, and the text blob. The mobile tooltip should consume `tooltip.controlItems` directly instead of re-parsing the string — you already pass `controlItems` to `showTooltip`, so they're available.
+
+**9. `inControlBlock` logic in `mobileTooltipData` will silently drop data**
+
+```ts
+if (line === 'Control:') {
+  inControlBlock = true;
+  continue;
+}
+if (inControlBlock) {
+  const isKeyValueLine = /^[A-Za-z ]+:\s/.test(line);
+  if (!isKeyValueLine) continue;
+  inControlBlock = false;
+}
+```
+
+This skips all control percentage lines since they match `Faction Name 45% · P3` (no colon-value pattern). The intent is correct but the control block stripping depends on the exact text format from `buildTooltipText`. Directly using `tooltip.controlItems` (point 8 above) eliminates this entirely.
+
+**10. Retained typo from `main`**
+
+`settings.flashActivePlayes` (missing 'r') — already existed before this branch, but since `StarSystem.tsx` is being touched extensively, worth fixing now.
+
+---
+
+### Tests
+
+The two new test files (`gm.interactions.test.ts`, `gm.selectors.test.ts`) cover `getDistance` and `buildFactionFilterOptions`. Good baseline. The hooks (`useGalaxyViewport`, `usePinchZoom`, `useTooltip`) and the `devStateInjector` have no tests. The injector in particular has branching logic worth unit-testing (`isTruthyFlag`, `isStateOverrideMap`, preset selection, named overrides).
+
+---
+
+## Summary
+
+| Area | Status |
+|---|---|
+| Hook extraction | Clean |
+| Viewport culling | Correct |
+| System state visuals | Works, minor animation restart issue |
+| `zoomScaleFactor` during pinch | Bug — not updated mid-gesture |
+| SSR/window guard in `useGalaxyViewport` | Missing on init |
+| Mobile tooltip data source | Should use `controlItems`, not re-parse text |
+| Desktop tooltip stale closure | Low-risk now, will break if font size becomes state |
+| Icon loader duplication | Minor DRY issue |
+| Test coverage | Good for utilities, missing for hooks/injector |

--- a/src/components/helpers/FactionHelper.ts
+++ b/src/components/helpers/FactionHelper.ts
@@ -4,10 +4,5 @@ export function findFaction(
   factionKey: string,
   factions: FactionDataType
 ): FactionType | undefined {
-  const findResult = Object.entries(factions).find(
-    ([key]) => key === factionKey
-  );
-
-  const faction = findResult?.[1];
-  return faction;
+  return factions[factionKey];
 }

--- a/src/components/helpers/devStateInjector.ts
+++ b/src/components/helpers/devStateInjector.ts
@@ -6,43 +6,25 @@ const ENABLE_STORAGE_KEY = 'warMapDevStateTest';
 const PRESET_STORAGE_KEY = 'warMapDevStatePreset';
 const OVERRIDES_STORAGE_KEY = 'warMapDevStateOverrides';
 const DEV_INSURRECTION_SYSTEMS = [
-  'Terra',
-  'Altair',
-  'Asta',
-  'Bryant',
-  'Caph',
-  'Dieron',
-  'Epsilon Eridani',
-  'Fomalhaut',
-  'Keid',
-  'New Home',
-  'New Stevens',
-  'Saffel',
+  'Tainjin',
+  "Ma'anshan",
+  'Millerton',
+  'Moriguchi',
+  'Nouasseur',
+  'Qanatir',
+  'Zwipadze',
 ];
 const DEV_PIRATE_RAID_SYSTEMS = [
-  'Conwy',
-  'Algol',
-  'Algot',
-  'Almach',
-  'Alrescha',
-  'Buchlau',
-  'Demeter',
-  'Foochow',
-  'Halloran',
-  'Hunan',
-  'Kansu',
-  'Menkar',
-  'New Aragon',
-  'New Hessen',
-  'Ningpo',
-  'Pleione',
-  'Poznan',
-  'Slocum',
-  'Tianamon',
-  'Yangtze',
+  'Bougie',
+  'Beauvais',
+  'Cilvituk',
+  'Melilla',
+  'Naco',
+  'Sialkot',
+  'Zefri',
 ];
-const DEV_HOLD_THE_LINE_SYSTEMS = ['Alnadal'];
-const DEV_CAPTURE_EVENT_SYSTEMS = ['Rowe'];
+const DEV_HOLD_THE_LINE_SYSTEMS = ['Port Vail (The Rack 3050+)'];
+const DEV_CAPTURE_EVENT_SYSTEMS = ['Wiltshire'];
 
 type StateOverrideMap = Record<string, StarSystemState>;
 
@@ -50,6 +32,18 @@ const isTruthyFlag = (value: string | null) => {
   if (!value) return false;
   const normalized = value.trim().toLowerCase();
   return normalized !== '0' && normalized !== 'false' && normalized !== 'off';
+};
+
+const getQueryParamCaseInsensitive = (
+  params: URLSearchParams,
+  paramName: string
+): string | null => {
+  for (const [key, value] of params) {
+    if (key.toLowerCase() === paramName.toLowerCase()) {
+      return value;
+    }
+  }
+  return null;
 };
 
 const isStateOverrideMap = (value: unknown): value is StateOverrideMap => {
@@ -70,6 +64,38 @@ const isStateOverrideMap = (value: unknown): value is StateOverrideMap => {
         typeof typed.hasHoldTheLineEvent === 'boolean')
     );
   });
+};
+
+const DEV_STATE_INJECTION_DEBUG =
+  import.meta.env.DEV || import.meta.env.VITE_ENABLE_STATE_TEST === 'true';
+
+const buildNamedEventOverrides = (
+  systems: StarSystemType[],
+  targetNames: string[],
+  stateKey: keyof StarSystemState,
+  stateValue: boolean
+): StateOverrideMap => {
+  const systemNameLookup = new Map(
+    systems.map((system) => [system.name.toLowerCase(), system.name])
+  );
+  const overrides: StateOverrideMap = {};
+
+  targetNames.forEach((targetName) => {
+    const canonicalName = systemNameLookup.get(targetName.toLowerCase());
+    if (!canonicalName) {
+      if (DEV_STATE_INJECTION_DEBUG) {
+        console.warn(
+          '[devStateInjector] target system not found for override:',
+          targetName
+        );
+      }
+      return;
+    }
+
+    overrides[canonicalName] = { [stateKey]: stateValue } as StarSystemState;
+  });
+
+  return overrides;
 };
 
 const buildSampleOverrides = (systems: StarSystemType[]): StateOverrideMap => {
@@ -126,71 +152,43 @@ const readOverridesFromStorage = (): StateOverrideMap | null => {
 
 const buildNamedInsurrectionOverrides = (
   systems: StarSystemType[]
-): StateOverrideMap => {
-  const systemNameLookup = new Map(
-    systems.map((system) => [system.name.toLowerCase(), system.name])
+): StateOverrideMap =>
+  buildNamedEventOverrides(
+    systems,
+    DEV_INSURRECTION_SYSTEMS,
+    'isInsurrect',
+    true
   );
-  const overrides: StateOverrideMap = {};
-
-  DEV_INSURRECTION_SYSTEMS.forEach((targetName) => {
-    const canonicalName = systemNameLookup.get(targetName.toLowerCase());
-    if (!canonicalName) return;
-    overrides[canonicalName] = { isInsurrect: true };
-  });
-
-  return overrides;
-};
 
 const buildNamedPirateRaidOverrides = (
   systems: StarSystemType[]
-): StateOverrideMap => {
-  const systemNameLookup = new Map(
-    systems.map((system) => [system.name.toLowerCase(), system.name])
+): StateOverrideMap =>
+  buildNamedEventOverrides(
+    systems,
+    DEV_PIRATE_RAID_SYSTEMS,
+    'hasPirateRaid',
+    true
   );
-  const overrides: StateOverrideMap = {};
-
-  DEV_PIRATE_RAID_SYSTEMS.forEach((targetName) => {
-    const canonicalName = systemNameLookup.get(targetName.toLowerCase());
-    if (!canonicalName) return;
-    overrides[canonicalName] = { hasPirateRaid: true };
-  });
-
-  return overrides;
-};
 
 const buildNamedHoldTheLineOverrides = (
   systems: StarSystemType[]
-): StateOverrideMap => {
-  const systemNameLookup = new Map(
-    systems.map((system) => [system.name.toLowerCase(), system.name])
+): StateOverrideMap =>
+  buildNamedEventOverrides(
+    systems,
+    DEV_HOLD_THE_LINE_SYSTEMS,
+    'hasHoldTheLineEvent',
+    true
   );
-  const overrides: StateOverrideMap = {};
-
-  DEV_HOLD_THE_LINE_SYSTEMS.forEach((targetName) => {
-    const canonicalName = systemNameLookup.get(targetName.toLowerCase());
-    if (!canonicalName) return;
-    overrides[canonicalName] = { hasHoldTheLineEvent: true };
-  });
-
-  return overrides;
-};
 
 const buildNamedCaptureEventOverrides = (
   systems: StarSystemType[]
-): StateOverrideMap => {
-  const systemNameLookup = new Map(
-    systems.map((system) => [system.name.toLowerCase(), system.name])
+): StateOverrideMap =>
+  buildNamedEventOverrides(
+    systems,
+    DEV_CAPTURE_EVENT_SYSTEMS,
+    'hasCaptureEvent',
+    true
   );
-  const overrides: StateOverrideMap = {};
-
-  DEV_CAPTURE_EVENT_SYSTEMS.forEach((targetName) => {
-    const canonicalName = systemNameLookup.get(targetName.toLowerCase());
-    if (!canonicalName) return;
-    overrides[canonicalName] = { hasCaptureEvent: true };
-  });
-
-  return overrides;
-};
 
 export const applyDevStateInjection = (
   systems: StarSystemType[]
@@ -201,8 +199,20 @@ export const applyDevStateInjection = (
 
   const params = new URLSearchParams(window.location.search);
   const enabled =
-    isTruthyFlag(params.get(ENABLE_QUERY_PARAM)) ||
+    isTruthyFlag(getQueryParamCaseInsensitive(params, ENABLE_QUERY_PARAM)) ||
     isTruthyFlag(window.localStorage.getItem(ENABLE_STORAGE_KEY));
+
+  if (DEV_STATE_INJECTION_DEBUG) {
+    console.debug('[devStateInjector] injection gate', {
+      allowInjectedStates,
+      query: window.location.search,
+      paramValue: getQueryParamCaseInsensitive(params, ENABLE_QUERY_PARAM),
+      localStorageKey: window.localStorage.getItem(ENABLE_STORAGE_KEY),
+      enabled,
+      presetParam: getQueryParamCaseInsensitive(params, PRESET_QUERY_PARAM),
+      presetStorage: window.localStorage.getItem(PRESET_STORAGE_KEY),
+    });
+  }
 
   if (!enabled) return systems;
 
@@ -229,7 +239,26 @@ export const applyDevStateInjection = (
     ...customOverrides,
   };
 
-  if (!Object.keys(overrides).length) return systems;
+  if (DEV_STATE_INJECTION_DEBUG) {
+    console.debug('[devStateInjector] overrides', {
+      preset,
+      totalOverrides: Object.keys(overrides).length,
+      namedInsurrection: Object.keys(namedInsurrectionOverrides).length,
+      namedPirateRaid: Object.keys(namedPirateRaidOverrides).length,
+      namedHoldTheLine: Object.keys(namedHoldTheLineOverrides).length,
+      namedCaptureEvent: Object.keys(namedCaptureEventOverrides).length,
+      customOverrides: customOverrides
+        ? Object.keys(customOverrides).length
+        : 0,
+    });
+  }
+
+  if (!Object.keys(overrides).length) {
+    if (DEV_STATE_INJECTION_DEBUG) {
+      console.warn('[devStateInjector] no dev state overrides were applied');
+    }
+    return systems;
+  }
 
   return systems.map((system) => {
     const injected = overrides[system.name];

--- a/src/components/hooks/types/DisplayStarSystemType.ts
+++ b/src/components/hooks/types/DisplayStarSystemType.ts
@@ -1,6 +1,7 @@
 import type { StarSystemWithState } from './StarSystemWithState';
 
 export type DisplayStarSystemType = StarSystemWithState & {
+  id: string;
   isCapital: boolean;
   factionColour: string;
   factionName: string;

--- a/src/components/hooks/types/DisplayStarSystemType.ts
+++ b/src/components/hooks/types/DisplayStarSystemType.ts
@@ -4,4 +4,5 @@ export type DisplayStarSystemType = StarSystemWithState & {
   isCapital: boolean;
   factionColour: string;
   factionName: string;
+  normalizedName: string;
 };

--- a/src/components/hooks/types/Settings.ts
+++ b/src/components/hooks/types/Settings.ts
@@ -1,7 +1,7 @@
 export interface Settings {
-  flashActivePlayes: boolean;
+  flashActivePlayers: boolean;
 }
 
 export const initialSettings: Settings = {
-  flashActivePlayes: true,
+  flashActivePlayers: true,
 };

--- a/src/components/hooks/useFiltering.ts
+++ b/src/components/hooks/useFiltering.ts
@@ -1,17 +1,15 @@
-import { useCallback, useEffect, useState } from 'react';
-import { findFaction, isCapital } from '../helpers';
+import { useCallback, useMemo } from 'react';
+import { findFaction } from '../helpers';
 import { DisplayStarSystemType, StarSystemType } from './types';
 import useWarmapAPI from './useWarmapAPI';
 import useSettings from './useSettings';
 
 const useFiltering = () => {
-  const [displaySystems, setDisplaySystems] = useState<DisplayStarSystemType[]>(
-    []
-  );
   const { rawSystems, factions, capitals, fetchFactionData, fetchSystemData } =
     useWarmapAPI();
 
   const { settings, setFlashActive } = useSettings();
+  const capitalSet = useMemo(() => new Set(capitals), [capitals]);
 
   const projectSystemData = useCallback(
     (rawSystems: StarSystemType[]): DisplayStarSystemType[] => {
@@ -20,21 +18,22 @@ const useFiltering = () => {
         const displayName = faction?.prettyName ?? 'Unknown Faction';
         const projectedSystem: DisplayStarSystemType = {
           ...value,
-          isCapital: isCapital(value.name, capitals),
+          isCapital: capitalSet.has(value.name),
           factionColour: faction && faction.colour ? faction.colour : 'gray',
           factionName: displayName,
+          normalizedName: value.name.toLowerCase(),
         };
 
         return projectedSystem;
       });
     },
-    [capitals, factions]
+    [capitalSet, factions]
   );
 
-  useEffect(() => {
-    const projectedSystems = projectSystemData(rawSystems);
-    setDisplaySystems(projectedSystems);
-  }, [rawSystems, capitals, factions, projectSystemData]);
+  const displaySystems = useMemo(
+    () => projectSystemData(rawSystems),
+    [projectSystemData, rawSystems]
+  );
 
   return {
     displaySystems,

--- a/src/components/hooks/useFiltering.ts
+++ b/src/components/hooks/useFiltering.ts
@@ -18,6 +18,7 @@ const useFiltering = () => {
         const displayName = faction?.prettyName ?? 'Unknown Faction';
         const projectedSystem: DisplayStarSystemType = {
           ...value,
+          id: `${value.name}-${value.posX}-${value.posY}`,
           isCapital: capitalSet.has(value.name),
           factionColour: faction && faction.colour ? faction.colour : 'gray',
           factionName: displayName,

--- a/src/components/hooks/useGalaxyViewport.ts
+++ b/src/components/hooks/useGalaxyViewport.ts
@@ -22,8 +22,22 @@ export function useGalaxyViewport({
     y: window.innerHeight / 2,
   });
 
-  // Exposes current scale to React consumers that need rerenders (like star node sizing).
+  // Exposes current scale and position to React consumers that need rerenders.
   const [zoomScaleFactor, setZoomScaleFactor] = useState<number>(1);
+  const [renderPosition, setRenderPosition] = useState<Point>(
+    positionRef.current
+  );
+  const positionUpdateRequestedRef = useRef(false);
+
+  const schedulePositionUpdate = useCallback(() => {
+    if (positionUpdateRequestedRef.current) return;
+    positionUpdateRequestedRef.current = true;
+
+    requestAnimationFrame(() => {
+      setRenderPosition(positionRef.current);
+      positionUpdateRequestedRef.current = false;
+    });
+  }, []);
 
   // Batch draw calls per animation frame to avoid a Konva redraw storm during drag/zoom.
   const frameRequestedRef = useRef(false);
@@ -78,25 +92,35 @@ export function useGalaxyViewport({
       stage.position(positionRef.current);
 
       requestBatchDraw(stage);
-
+      schedulePositionUpdate();
       setZoomScaleFactor(newScale);
     },
-    [maxScale, minScale, requestBatchDraw, wheelThrottleMs]
+    [
+      maxScale,
+      minScale,
+      requestBatchDraw,
+      schedulePositionUpdate,
+      wheelThrottleMs,
+    ]
   );
 
-  const onDragMove = useCallback((e: Konva.KonvaEventObject<DragEvent>) => {
-    positionRef.current = { x: e.target.x(), y: e.target.y() };
-  }, []);
+  const onDragMove = useCallback(
+    (e: Konva.KonvaEventObject<DragEvent>) => {
+      positionRef.current = { x: e.target.x(), y: e.target.y() };
+      schedulePositionUpdate();
+    },
+    [schedulePositionUpdate]
+  );
 
   // Build a memoized snapshot consumed by Stage props and tooltip scaling.
   // It intentionally updates only on React render so we avoid excess calculations.
   const view: ViewTransform = useMemo(
     () => ({
       scale: scaleRef.current,
-      position: positionRef.current,
+      position: renderPosition,
     }),
     // Re-render is required here because refs update without triggering React by design.
-    [zoomScaleFactor]
+    [renderPosition, zoomScaleFactor]
   );
 
   return {

--- a/src/components/hooks/useGalaxyViewport.ts
+++ b/src/components/hooks/useGalaxyViewport.ts
@@ -18,8 +18,8 @@ export function useGalaxyViewport({
 
   const scaleRef = useRef<number>(1);
   const positionRef = useRef<Point>({
-    x: window.innerWidth / 2,
-    y: window.innerHeight / 2,
+    x: typeof window !== 'undefined' ? window.innerWidth / 2 : 0,
+    y: typeof window !== 'undefined' ? window.innerHeight / 2 : 0,
   });
 
   // Exposes current scale and position to React consumers that need rerenders.

--- a/src/components/hooks/usePinchZoom.ts
+++ b/src/components/hooks/usePinchZoom.ts
@@ -127,6 +127,7 @@ export function usePinchZoom({
         stage.position(newPos);
 
         requestBatchDraw(stage);
+        setZoomScaleFactor(newScale);
 
         lastDistance.current = newDistance;
       });

--- a/src/components/hooks/useSettings.ts
+++ b/src/components/hooks/useSettings.ts
@@ -5,7 +5,7 @@ const useSettings = () => {
   const [settings, setSettingState] = useState<Settings>(initialSettings);
 
   const setFlashActive = (state: boolean) => {
-    setSettingState({ ...settings, flashActivePlayes: state });
+    setSettingState({ ...settings, flashActivePlayers: state });
   };
 
   return {

--- a/src/components/pages/GalaxyMap.tsx
+++ b/src/components/pages/GalaxyMap.tsx
@@ -4,9 +4,14 @@ import {
   ViewTransform,
 } from '../GalaxyMap/gm.types';
 import { buildFactionFilterOptions } from '../GalaxyMap/gm.selectors';
-import { useMemo, useEffect, useRef, useState } from 'react';
+import {
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { Stage, Layer, Image, Text, Group, Rect, Line } from 'react-konva';
-import Konva from 'konva';
 import StarSystem from '../ui/StarSystem';
 import BottomFilterPanel from '../ui/BottomFilterPanel';
 import useTooltip from '../hooks/useTooltip';
@@ -16,6 +21,11 @@ import { usePinchZoom } from '../hooks/usePinchZoom';
 
 const MIN_SCALE = 0.2;
 const MAX_SCALE = 25;
+const TOOLTIP_FONT_FAMILY = 'Roboto Mono, monospace';
+const tooltipMeasureContext =
+  typeof document !== 'undefined'
+    ? document.createElement('canvas').getContext('2d')
+    : null;
 
 const getViewportSize = () => {
   if (typeof window === 'undefined') {
@@ -34,6 +44,19 @@ const getTooltipFontSize = () => {
   }
 
   return parseFloat(getComputedStyle(document.documentElement).fontSize) * 0.85;
+};
+
+const measureTooltipTextWidth = (
+  text: string,
+  fontSize: number,
+  fontStyle: 'bold' | 'normal'
+) => {
+  if (!tooltipMeasureContext) {
+    return text.length * fontSize * 0.6;
+  }
+
+  tooltipMeasureContext.font = `${fontStyle} ${fontSize}px ${TOOLTIP_FONT_FAMILY}`;
+  return tooltipMeasureContext.measureText(text).width;
 };
 
 const GalaxyMap = () => {
@@ -100,8 +123,9 @@ const GalaxyMapRender = ({
     handlers: { onWheel, onDragMove },
   } = useGalaxyViewport();
   const [searchTerm, setSearchTerm] = useState('');
+  const deferredSearchTerm = useDeferredValue(searchTerm);
   const [showAllControl, setShowAllControl] = useState(false);
-  const normalizedSearch = searchTerm.trim().toLowerCase();
+  const normalizedSearch = deferredSearchTerm.trim().toLowerCase();
   const shouldFilter = normalizedSearch.length >= 2;
 
   /* Empty means "all factions"; when populated, only matching owners are rendered. */
@@ -259,6 +283,10 @@ const GalaxyMapRender = ({
   const tooltipScale = isMobile ? 1.5 / view.scale : 2 / view.scale;
   const tooltipFontSize = getTooltipFontSize();
   const desktopTooltipPadding = 6;
+  const factionOptions = useMemo(
+    () => buildFactionFilterOptions(systems, factions),
+    [systems, factions]
+  );
 
   const getViewportBounds = (
     stageSize: StageSize,
@@ -285,22 +313,67 @@ const GalaxyMapRender = ({
 
   const visibleSystems = useMemo(() => {
     const viewport = getViewportBounds(stageSize, view, 120);
+    const selectedFactionsSet = new Set(selectedFactions);
+
     return systems.filter((system) => {
       const x = Number(system.posX);
       const y = -Number(system.posY);
+
+      if (
+        x < viewport.left ||
+        x > viewport.right ||
+        y < viewport.top ||
+        y > viewport.bottom
+      ) {
+        return false;
+      }
+
       return (
-        x >= viewport.left &&
-        x <= viewport.right &&
-        y >= viewport.top &&
-        y <= viewport.bottom
+        !selectedFactionsSet.size ||
+        selectedFactionsSet.has(system.factionName)
       );
     });
-  }, [systems, stageSize, view]);
+  }, [selectedFactions, stageSize, systems, view]);
   const desktopPointerHeight = 10;
   const desktopPointerWidth = 12;
   const desktopTitleFontSize = tooltipFontSize * 1.12;
   const desktopBodyFontSize = tooltipFontSize * 0.92;
   const desktopLineHeight = desktopTitleFontSize * 1.2;
+
+  const renderedSystems = useMemo(
+    () =>
+      visibleSystems.map((system) => {
+        const isMatch =
+          !shouldFilter || system.normalizedName.includes(normalizedSearch);
+        const opacity = shouldFilter ? (isMatch ? 1 : 0.2) : 1;
+
+        return (
+          <StarSystem
+            key={`${system.name}-${system.posX}-${system.posY}-${system.owner}`}
+            zoomScaleFactor={zoomScaleFactor < 1 ? zoomScaleFactor : 1}
+            system={system}
+            factions={factions}
+            settings={settings}
+            showTooltip={showTooltip}
+            hideTooltip={hideTooltip}
+            tooltipVisibleRef={tooltipVisibleRef}
+            touchedSystemNameRef={touchedSystemNameRef}
+            highlighted={shouldFilter && isMatch}
+            opacity={opacity}
+          />
+        );
+      }),
+    [
+      factions,
+      hideTooltip,
+      normalizedSearch,
+      settings,
+      shouldFilter,
+      showTooltip,
+      visibleSystems,
+      zoomScaleFactor,
+    ]
+  );
 
   const getDesktopLineSegments = (line: string, index: number) => {
     if (index === 0) {
@@ -350,15 +423,14 @@ const GalaxyMapRender = ({
     const lines = desktopTooltipLines.length ? desktopTooltipLines : [''];
     const widths = lines.map((line, index) =>
       getDesktopLineSegments(line, index).reduce((sum, segment) => {
-        const measure = new Konva.Text({
-          text: segment.text,
-          fontFamily: 'Roboto Mono, monospace',
-          fontSize: segment.fontSize,
-          fontStyle: segment.fontStyle,
-        });
-        const width = measure.width();
-        measure.destroy();
-        return sum + width;
+        return (
+          sum +
+          measureTooltipTextWidth(
+            segment.text,
+            segment.fontSize,
+            segment.fontStyle
+          )
+        );
       }, 0)
     );
 
@@ -472,35 +544,7 @@ const GalaxyMapRender = ({
           )}
         </Layer>
         <Layer>
-          {visibleSystems.map((system) => {
-            /* Resolve owner display name via faction metadata for consistent filter matching and labels. */
-            const ownerPretty =
-              factions[system.owner]?.prettyName ?? system.owner;
-            const factionMatch =
-              !selectedFactions.length ||
-              selectedFactions.includes(ownerPretty);
-            if (!factionMatch) return null;
-
-            const isMatch = system.name
-              .toLowerCase()
-              .includes(normalizedSearch);
-            const opacity = shouldFilter ? (isMatch ? 1 : 0.2) : 1;
-            return (
-              <StarSystem
-                key={`${system.name}-${system.posX}-${system.posY}-${system.owner}`}
-                zoomScaleFactor={zoomScaleFactor < 1 ? zoomScaleFactor : 1}
-                system={system}
-                factions={factions}
-                settings={settings}
-                showTooltip={showTooltip}
-                hideTooltip={hideTooltip}
-                tooltipVisibleRef={tooltipVisibleRef}
-                touchedSystemNameRef={touchedSystemNameRef}
-                highlighted={shouldFilter && isMatch}
-                opacity={opacity}
-              />
-            );
-          })}
+          {renderedSystems}
         </Layer>
         <Layer>
           {tooltip.visible && !isMobile && (
@@ -559,15 +603,14 @@ const GalaxyMapRender = ({
                         const segmentOffset = segments
                           .slice(0, segmentIndex)
                           .reduce((sum, previousSegment) => {
-                            const measure = new Konva.Text({
-                              text: previousSegment.text,
-                              fontFamily: 'Roboto Mono, monospace',
-                              fontSize: previousSegment.fontSize,
-                              fontStyle: previousSegment.fontStyle,
-                            });
-                            const width = measure.width();
-                            measure.destroy();
-                            return sum + width;
+                            return (
+                              sum +
+                              measureTooltipTextWidth(
+                                previousSegment.text,
+                                previousSegment.fontSize,
+                                previousSegment.fontStyle
+                              )
+                            );
                           }, 0);
 
                         return (
@@ -576,7 +619,7 @@ const GalaxyMapRender = ({
                             x={segmentOffset}
                             y={0}
                             text={segment.text}
-                            fontFamily="Roboto Mono, monospace"
+                            fontFamily={TOOLTIP_FONT_FAMILY}
                             fontSize={segment.fontSize}
                             fontStyle={segment.fontStyle}
                             fill="black"
@@ -697,10 +740,7 @@ const GalaxyMapRender = ({
       <BottomFilterPanel
         searchTerm={searchTerm}
         setSearchTerm={setSearchTerm}
-        factions={useMemo(
-          () => buildFactionFilterOptions(systems, factions),
-          [systems, factions]
-        )}
+        factions={factionOptions}
         selectedFactions={selectedFactions}
         setSelectedFactions={setSelectedFactions}
       />

--- a/src/components/pages/GalaxyMap.tsx
+++ b/src/components/pages/GalaxyMap.tsx
@@ -1,6 +1,7 @@
 import {
   StageSize,
   GalaxyMapRenderProps,
+  ViewTransform,
 } from '../GalaxyMap/gm.types';
 import { buildFactionFilterOptions } from '../GalaxyMap/gm.selectors';
 import { useMemo, useEffect, useRef, useState } from 'react';
@@ -258,6 +259,43 @@ const GalaxyMapRender = ({
   const tooltipScale = isMobile ? 1.5 / view.scale : 2 / view.scale;
   const tooltipFontSize = getTooltipFontSize();
   const desktopTooltipPadding = 6;
+
+  const getViewportBounds = (
+    stageSize: StageSize,
+    view: ViewTransform,
+    screenMargin = 120
+  ) => {
+    if (stageSize.width <= 0 || stageSize.height <= 0) {
+      return {
+        left: Number.NEGATIVE_INFINITY,
+        right: Number.POSITIVE_INFINITY,
+        top: Number.NEGATIVE_INFINITY,
+        bottom: Number.POSITIVE_INFINITY,
+      };
+    }
+
+    const margin = Math.max(screenMargin / view.scale, 1);
+    const left = (0 - view.position.x) / view.scale - margin;
+    const top = (0 - view.position.y) / view.scale - margin;
+    const right = (stageSize.width - view.position.x) / view.scale + margin;
+    const bottom = (stageSize.height - view.position.y) / view.scale + margin;
+
+    return { left, right, top, bottom };
+  };
+
+  const visibleSystems = useMemo(() => {
+    const viewport = getViewportBounds(stageSize, view, 120);
+    return systems.filter((system) => {
+      const x = Number(system.posX);
+      const y = -Number(system.posY);
+      return (
+        x >= viewport.left &&
+        x <= viewport.right &&
+        y >= viewport.top &&
+        y <= viewport.bottom
+      );
+    });
+  }, [systems, stageSize, view]);
   const desktopPointerHeight = 10;
   const desktopPointerWidth = 12;
   const desktopTitleFontSize = tooltipFontSize * 1.12;
@@ -422,7 +460,9 @@ const GalaxyMapRender = ({
             />
           ) : (
             <Text
-              text={bgLoadError ? 'Background unavailable' : 'Loading Background...'}
+              text={
+                bgLoadError ? 'Background unavailable' : 'Loading Background...'
+              }
               x={stageSize.width / 2}
               y={stageSize.height / 2}
               fontSize={24}
@@ -432,7 +472,7 @@ const GalaxyMapRender = ({
           )}
         </Layer>
         <Layer>
-          {systems.map((system) => {
+          {visibleSystems.map((system) => {
             /* Resolve owner display name via faction metadata for consistent filter matching and labels. */
             const ownerPretty =
               factions[system.owner]?.prettyName ?? system.owner;

--- a/src/components/pages/GalaxyMap.tsx
+++ b/src/components/pages/GalaxyMap.tsx
@@ -350,8 +350,8 @@ const GalaxyMapRender = ({
 
         return (
           <StarSystem
-            key={`${system.name}-${system.posX}-${system.posY}-${system.owner}`}
-            zoomScaleFactor={zoomScaleFactor < 1 ? zoomScaleFactor : 1}
+            key={system.id}
+            scaleRef={scaleRef}
             system={system}
             factions={factions}
             settings={settings}
@@ -368,11 +368,11 @@ const GalaxyMapRender = ({
       factions,
       hideTooltip,
       normalizedSearch,
+      scaleRef,
       settings,
       shouldFilter,
       showTooltip,
       visibleSystems,
-      zoomScaleFactor,
     ]
   );
 

--- a/src/components/pages/GalaxyMap.tsx
+++ b/src/components/pages/GalaxyMap.tsx
@@ -118,7 +118,6 @@ const GalaxyMapRender = ({
     scaleRef,
     positionRef,
     view,
-    zoomScaleFactor,
     requestBatchDraw,
     setZoomScaleFactor,
     handlers: { onWheel, onDragMove },

--- a/src/components/pages/GalaxyMap.tsx
+++ b/src/components/pages/GalaxyMap.tsx
@@ -5,6 +5,7 @@ import {
 } from '../GalaxyMap/gm.types';
 import { buildFactionFilterOptions } from '../GalaxyMap/gm.selectors';
 import {
+  useCallback,
   useDeferredValue,
   useEffect,
   useMemo,
@@ -375,7 +376,7 @@ const GalaxyMapRender = ({
     ]
   );
 
-  const getDesktopLineSegments = (line: string, index: number) => {
+  const getDesktopLineSegments = useCallback((line: string, index: number) => {
     if (index === 0) {
       return [
         {
@@ -412,7 +413,7 @@ const GalaxyMapRender = ({
         fontSize: desktopBodyFontSize,
       },
     ];
-  };
+  }, [desktopTitleFontSize, desktopBodyFontSize]);
 
   const desktopTooltipLines = useMemo(
     () => (tooltip.text || '').split('\n').map((line) => line.trimEnd()),
@@ -439,7 +440,7 @@ const GalaxyMapRender = ({
     const boxHeight =
       lines.length * desktopLineHeight + desktopTooltipPadding * 2;
     return { lines, boxWidth, boxHeight };
-  }, [desktopTooltipLines, tooltipFontSize, desktopLineHeight]);
+  }, [desktopTooltipLines, desktopLineHeight, getDesktopLineSegments]);
 
   useEffect(() => {
     if (tooltip.visible) {

--- a/src/components/pages/GalaxyMap.tsx
+++ b/src/components/pages/GalaxyMap.tsx
@@ -468,25 +468,13 @@ const GalaxyMapRender = ({
     const title = lines[0] ?? '';
     const subtitle = lines[1]?.startsWith('(') ? lines[1] : '';
     const rawDetails = lines.slice(subtitle ? 2 : 1);
-    const details: string[] = [];
-    let inControlBlock = false;
 
-    for (const line of rawDetails) {
-      if (line === 'Control:') {
-        inControlBlock = true;
-        continue;
-      }
-
-      if (inControlBlock) {
-        const isKeyValueLine = /^[A-Za-z ]+:\s/.test(line);
-        if (!isKeyValueLine) {
-          continue;
-        }
-        inControlBlock = false;
-      }
-
-      details.push(line);
-    }
+    // Control lines are rendered separately via tooltip.controlItems — keep only
+    // the known labelled fields so faction percentage lines are never silently dropped.
+    const DETAIL_PREFIXES = ['Owner:', 'Damage:', 'State:'];
+    const details = rawDetails.filter((line) =>
+      DETAIL_PREFIXES.some((prefix) => line.startsWith(prefix))
+    );
 
     return { title, subtitle, details };
   }, [tooltip.text]);

--- a/src/components/ui/BottomFilterPanel.tsx
+++ b/src/components/ui/BottomFilterPanel.tsx
@@ -1,6 +1,30 @@
-import { useState, useEffect, useRef } from 'react';
-import Select, { MultiValue } from 'react-select';
-import { ChevronsUp, ChevronsDown } from 'lucide-react';
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react';
+import type { MultiValue } from 'react-select';
+import { ChevronsDown, ChevronsUp } from 'lucide-react';
+
+const FactionSelect = lazy(() => import('react-select'));
+
+type FactionOption = {
+  value: string;
+  label: string;
+};
+
+const selectStyles = {
+  control: (base: object) => ({
+    ...base,
+    color: 'black',
+    width: '100%',
+  }),
+  input: (base: object) => ({ ...base, color: 'black' }),
+  singleValue: (base: object) => ({ ...base, color: 'black' }),
+  multiValueLabel: (base: object) => ({ ...base, color: 'black' }),
+  option: (base: object, state: { isFocused: boolean }) => ({
+    ...base,
+    color: 'black',
+    backgroundColor: state.isFocused ? '#e6e6e6' : 'white',
+  }),
+  menuPortal: (base: object) => ({ ...base, zIndex: 9999 }),
+};
 
 const BottomFilterPanel = ({
   searchTerm,
@@ -17,53 +41,52 @@ const BottomFilterPanel = ({
 }) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  /* Desktop/mobile layout mode is driven by viewport width and updated on resize. */
   const [isDesktop, setIsDesktop] = useState(
     typeof window !== 'undefined' && window.innerWidth >= 768
   );
+
   useEffect(() => {
     const onResize = () => setIsDesktop(window.innerWidth >= 768);
     window.addEventListener('resize', onResize);
     return () => window.removeEventListener('resize', onResize);
   }, []);
 
-  /* Build react-select option/value pairs from faction names for stable controlled input state. */
-  const options = factions.map((f) => ({ value: f, label: f }));
-  const selectedOpts = options.filter((o) =>
-    selectedFactions.includes(o.value)
+  const options = useMemo<FactionOption[]>(
+    () => factions.map((faction) => ({ value: faction, label: faction })),
+    [factions]
   );
-  const onFactionChange = (
-    vals: MultiValue<{ value: string; label: string }>
-  ) => setSelectedFactions(vals.map((v) => v.value));
+
+  const selectedOpts = useMemo(
+    () => options.filter((option) => selectedFactions.includes(option.value)),
+    [options, selectedFactions]
+  );
+
+  const onFactionChange = (vals: unknown) =>
+    setSelectedFactions(
+      (vals as MultiValue<FactionOption>).map((value) => value.value)
+    );
 
   const removeFaction = (name: string) =>
-    setSelectedFactions(selectedFactions.filter((f) => f !== name));
+    setSelectedFactions(selectedFactions.filter((faction) => faction !== name));
 
   const panelRef = useRef<HTMLDivElement>(null);
   const [height, setHeight] = useState<string>('32px');
-
   const [showTooltip, setShowTooltip] = useState(false);
 
   useEffect(() => {
     const panel = panelRef.current;
     if (!panel) return;
 
-    // Measure the current height so height animation starts from an exact frame.
     const startHeight = panel.offsetHeight;
-
-    // Disable transitions temporarily so we can snapshot the target height without an
-    // intermediate animated jump.
     panel.style.transition = 'none';
     panel.style.height = 'auto';
 
     const targetHeight = panel.scrollHeight;
 
-    // Re-enable transition and restore the measured start height before animating.
     requestAnimationFrame(() => {
       panel.style.transition = 'height 0.5s ease';
       panel.style.height = `${startHeight}px`;
 
-      // Apply the final target height in the next frame to trigger a clean transition.
       requestAnimationFrame(() => {
         const expandedHeight = Math.max(targetHeight, 125);
         setHeight(`${isOpen ? expandedHeight : 32}px`);
@@ -84,8 +107,8 @@ const BottomFilterPanel = ({
     maxWidth: isDesktop ? '220px' : '90vw',
     zIndex: 10000,
     ...(isDesktop
-      ? { bottom: 22, left: 0 } // Desktop tooltip aligns under the help icon.
-      : { bottom: 28, right: 8, left: 'auto', transform: 'none' }), // Mobile tooltip floats centered under the icon.
+      ? { bottom: 22, left: 0 }
+      : { bottom: 28, right: 8, left: 'auto', transform: 'none' }),
   };
 
   return (
@@ -110,7 +133,6 @@ const BottomFilterPanel = ({
         opacity: isOpen ? 1 : 0.5,
       }}
     >
-      {/* Header trigger lets users expand/collapse the bottom filter panel. */}
       <div
         style={{
           display: 'flex',
@@ -123,7 +145,6 @@ const BottomFilterPanel = ({
         {isOpen ? <ChevronsDown size={24} /> : <ChevronsUp size={24} />}
       </div>
 
-      {/* Open state uses two columns: left = search, right = faction filters. */}
       {isOpen && (
         <div
           style={{
@@ -132,15 +153,14 @@ const BottomFilterPanel = ({
             height: '100%',
           }}
         >
-           {/* Left column: system search field */}
           <div style={{ flex: 1, paddingRight: '0.75rem' }}>
             <input
               type="text"
-              placeholder="Search systems…"
+              placeholder="Search systems..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
               style={{
-                width: isDesktop ? '50%' : '100%', // Desktop keeps a compact search field width.
+                width: isDesktop ? '50%' : '100%',
                 padding: '6px 10px',
                 fontSize: '16px',
                 borderRadius: '6px',
@@ -148,12 +168,11 @@ const BottomFilterPanel = ({
                 outline: 'none',
                 backgroundColor: 'white',
                 color: 'black',
-                margin: '0 0.25rem 0.5rem', // Add spacing so pills and controls are not crowded.
+                margin: '0 0.25rem 0.5rem',
               }}
             />
           </div>
 
-           {/* Right column: faction selector controls */}
           <div
             style={{
               flex: 1,
@@ -166,32 +185,31 @@ const BottomFilterPanel = ({
                 style={{ display: 'flex', alignItems: 'center', gap: '8px' }}
               >
                 <div style={{ flexGrow: 1 }}>
-                  <Select
-                    isMulti
-                    options={options}
-                    value={selectedOpts}
-                    onChange={onFactionChange}
-                    menuPortalTarget={document.body}
-                    menuPlacement="top"
-                    placeholder="Filter factions…"
-                    components={{ MultiValue: () => null }}
-                    styles={{
-                      control: (base) => ({
-                        ...base,
-                        color: 'black',
-                        width: '100%',
-                      }),
-                      input: (base) => ({ ...base, color: 'black' }),
-                      singleValue: (base) => ({ ...base, color: 'black' }),
-                      multiValueLabel: (base) => ({ ...base, color: 'black' }),
-                      option: (base, state) => ({
-                        ...base,
-                        color: 'black',
-                        backgroundColor: state.isFocused ? '#e6e6e6' : 'white',
-                      }),
-                      menuPortal: (base) => ({ ...base, zIndex: 9999 }),
-                    }}
-                  />
+                  <Suspense
+                    fallback={
+                      <div
+                        style={{
+                          width: '100%',
+                          height: '38px',
+                          borderRadius: '6px',
+                          background: 'white',
+                          opacity: 0.85,
+                        }}
+                      />
+                    }
+                  >
+                    <FactionSelect
+                      isMulti
+                      options={options}
+                      value={selectedOpts}
+                      onChange={onFactionChange}
+                      menuPortalTarget={document.body}
+                      menuPlacement="top"
+                      placeholder="Filter factions..."
+                      components={{ MultiValue: () => null }}
+                      styles={selectStyles}
+                    />
+                  </Suspense>
                 </div>
 
                 <div
@@ -222,7 +240,6 @@ const BottomFilterPanel = ({
                 </div>
               </div>
 
-               {/* Selected factions appear as removable chips for quick feedback and edits. */}
               {selectedFactions.length > 0 && (
                 <div
                   style={{
@@ -232,9 +249,9 @@ const BottomFilterPanel = ({
                     gap: '4px',
                   }}
                 >
-                  {selectedFactions.map((f) => (
+                  {selectedFactions.map((faction) => (
                     <span
-                      key={f}
+                      key={faction}
                       style={{
                         display: 'flex',
                         alignItems: 'center',
@@ -245,9 +262,9 @@ const BottomFilterPanel = ({
                         borderRadius: '4px',
                       }}
                     >
-                      {f}
+                      {faction}
                       <span
-                        onClick={() => removeFaction(f)}
+                        onClick={() => removeFaction(faction)}
                         style={{
                           marginLeft: '4px',
                           cursor: 'pointer',

--- a/src/components/ui/StarSystem.tsx
+++ b/src/components/ui/StarSystem.tsx
@@ -299,20 +299,18 @@ const StarSystem: React.FC<StarSystemProps> = ({
     if (!shouldPulseSize || !systemCircleRef.current) return;
 
     const systemNode = systemCircleRef.current;
-    const pirateIconNode = pirateIconRef.current;
-    const holdTheLineIconNode = holdTheLineIconRef.current;
-    const captureEventIconNode = captureEventIconRef.current;
 
+    // Read icon nodes from refs each frame so the animation picks up newly-mounted
+    // icons without restarting — avoids a mid-frame glitch when an image loads.
     const animation = new Konva.Animation((frame) => {
       if (!frame) return;
       const wave = (Math.sin(frame.time * 0.0055) + 1) / 2;
       const scale = 0.92 + wave * 0.655;
 
       systemNode.scale({ x: scale, y: scale });
-      if (pirateIconNode) pirateIconNode.scale({ x: scale, y: scale });
-      if (holdTheLineIconNode) holdTheLineIconNode.scale({ x: scale, y: scale });
-      if (captureEventIconNode)
-        captureEventIconNode.scale({ x: scale, y: scale });
+      pirateIconRef.current?.scale({ x: scale, y: scale });
+      holdTheLineIconRef.current?.scale({ x: scale, y: scale });
+      captureEventIconRef.current?.scale({ x: scale, y: scale });
     }, systemNode.getLayer());
 
     animation.start();
@@ -320,11 +318,11 @@ const StarSystem: React.FC<StarSystemProps> = ({
     return () => {
       animation.stop();
       systemNode.scale({ x: 1, y: 1 });
-      if (pirateIconNode) pirateIconNode.scale({ x: 1, y: 1 });
-      if (holdTheLineIconNode) holdTheLineIconNode.scale({ x: 1, y: 1 });
-      if (captureEventIconNode) captureEventIconNode.scale({ x: 1, y: 1 });
+      pirateIconRef.current?.scale({ x: 1, y: 1 });
+      holdTheLineIconRef.current?.scale({ x: 1, y: 1 });
+      captureEventIconRef.current?.scale({ x: 1, y: 1 });
     };
-  }, [shouldPulseSize, pirateIconImage, holdTheLineIconImage, captureEventIconImage]);
+  }, [shouldPulseSize]);
 
   const damageLevelText =
     system.damageLevel !== undefined &&

--- a/src/components/ui/StarSystem.tsx
+++ b/src/components/ui/StarSystem.tsx
@@ -204,7 +204,7 @@ const StarSystem: React.FC<StarSystemProps> = ({
     }, group.getLayer());
 
     animation.start();
-    return () => animation.stop();
+    return () => { animation.stop(); };
   }, [scaleRef]);
 
   useEffect(() => {

--- a/src/components/ui/StarSystem.tsx
+++ b/src/components/ui/StarSystem.tsx
@@ -17,69 +17,32 @@ import type { TooltipControlItem } from '../GalaxyMap/gm.types';
 
 const CAPITAL_RADIUS = 2.5;
 const PLANET_RADIUS = 1;
-let pirateIconImageCache: HTMLImageElement | null = null;
-let pirateIconImagePromise: Promise<HTMLImageElement> | null = null;
-let holdTheLineIconImageCache: HTMLImageElement | null = null;
-let holdTheLineIconImagePromise: Promise<HTMLImageElement> | null = null;
-let captureEventIconImageCache: HTMLImageElement | null = null;
-let captureEventIconImagePromise: Promise<HTMLImageElement> | null = null;
 
-const loadPirateIconImage = (): Promise<HTMLImageElement> => {
-  if (pirateIconImageCache) return Promise.resolve(pirateIconImageCache);
-  if (pirateIconImagePromise) return pirateIconImagePromise;
+const makeIconLoader = (url: string) => {
+  let cache: HTMLImageElement | null = null;
+  let promise: Promise<HTMLImageElement> | null = null;
 
-  pirateIconImagePromise = new Promise((resolve, reject) => {
-    const image = new window.Image();
-    image.src = pirateIconUrl;
-    image.onload = () => {
-      pirateIconImageCache = image;
-      resolve(image);
-    };
-    image.onerror = () => {
-      reject(new Error('Failed to load pirate raid icon.'));
-    };
-  });
+  return (): Promise<HTMLImageElement> => {
+    if (cache) return Promise.resolve(cache);
+    if (promise) return promise;
 
-  return pirateIconImagePromise;
+    promise = new Promise((resolve, reject) => {
+      const image = new window.Image();
+      image.src = url;
+      image.onload = () => {
+        cache = image;
+        resolve(image);
+      };
+      image.onerror = () => reject(new Error(`Failed to load icon: ${url}`));
+    });
+
+    return promise;
+  };
 };
 
-const loadHoldTheLineIconImage = (): Promise<HTMLImageElement> => {
-  if (holdTheLineIconImageCache) return Promise.resolve(holdTheLineIconImageCache);
-  if (holdTheLineIconImagePromise) return holdTheLineIconImagePromise;
-
-  holdTheLineIconImagePromise = new Promise((resolve, reject) => {
-    const image = new window.Image();
-    image.src = holdTheLineIconUrl;
-    image.onload = () => {
-      holdTheLineIconImageCache = image;
-      resolve(image);
-    };
-    image.onerror = () => {
-      reject(new Error('Failed to load hold the line icon.'));
-    };
-  });
-
-  return holdTheLineIconImagePromise;
-};
-
-const loadCaptureEventIconImage = (): Promise<HTMLImageElement> => {
-  if (captureEventIconImageCache) return Promise.resolve(captureEventIconImageCache);
-  if (captureEventIconImagePromise) return captureEventIconImagePromise;
-
-  captureEventIconImagePromise = new Promise((resolve, reject) => {
-    const image = new window.Image();
-    image.src = captureEventIconUrl;
-    image.onload = () => {
-      captureEventIconImageCache = image;
-      resolve(image);
-    };
-    image.onerror = () => {
-      reject(new Error('Failed to load capture event icon.'));
-    };
-  });
-
-  return captureEventIconImagePromise;
-};
+const loadPirateIconImage = makeIconLoader(pirateIconUrl);
+const loadHoldTheLineIconImage = makeIconLoader(holdTheLineIconUrl);
+const loadCaptureEventIconImage = makeIconLoader(captureEventIconUrl);
 
 interface StarSystemProps {
   system: DisplayStarSystemType;
@@ -201,65 +164,29 @@ const StarSystem: React.FC<StarSystemProps> = ({
 
   useEffect(() => {
     if (!hasPirateRaid) return;
-    if (pirateIconImageCache) {
-      setPirateIconImage(pirateIconImageCache);
-      return;
-    }
-
     let cancelled = false;
     loadPirateIconImage()
-      .then((image) => {
-        if (!cancelled) setPirateIconImage(image);
-      })
-      .catch(() => {
-        if (!cancelled) setPirateIconImage(null);
-      });
-
-    return () => {
-      cancelled = true;
-    };
+      .then((image) => { if (!cancelled) setPirateIconImage(image); })
+      .catch(() => { if (!cancelled) setPirateIconImage(null); });
+    return () => { cancelled = true; };
   }, [hasPirateRaid]);
 
   useEffect(() => {
     if (!hasHoldTheLineEvent) return;
-    if (holdTheLineIconImageCache) {
-      setHoldTheLineIconImage(holdTheLineIconImageCache);
-      return;
-    }
-
     let cancelled = false;
     loadHoldTheLineIconImage()
-      .then((image) => {
-        if (!cancelled) setHoldTheLineIconImage(image);
-      })
-      .catch(() => {
-        if (!cancelled) setHoldTheLineIconImage(null);
-      });
-
-    return () => {
-      cancelled = true;
-    };
+      .then((image) => { if (!cancelled) setHoldTheLineIconImage(image); })
+      .catch(() => { if (!cancelled) setHoldTheLineIconImage(null); });
+    return () => { cancelled = true; };
   }, [hasHoldTheLineEvent]);
 
   useEffect(() => {
     if (!hasCaptureEvent) return;
-    if (captureEventIconImageCache) {
-      setCaptureEventIconImage(captureEventIconImageCache);
-      return;
-    }
-
     let cancelled = false;
     loadCaptureEventIconImage()
-      .then((image) => {
-        if (!cancelled) setCaptureEventIconImage(image);
-      })
-      .catch(() => {
-        if (!cancelled) setCaptureEventIconImage(null);
-      });
-
-    return () => {
-      cancelled = true;
-    };
+      .then((image) => { if (!cancelled) setCaptureEventIconImage(image); })
+      .catch(() => { if (!cancelled) setCaptureEventIconImage(null); });
+    return () => { cancelled = true; };
   }, [hasCaptureEvent]);
 
   useEffect(() => {

--- a/src/components/ui/StarSystem.tsx
+++ b/src/components/ui/StarSystem.tsx
@@ -146,7 +146,7 @@ const StarSystem: React.FC<StarSystemProps> = ({
   const isInsurrectionLike = isInsurrect || hasHoldTheLineEvent || hasCaptureEvent;
   const shouldPulseSize = hasPirateRaid || hasHoldTheLineEvent || hasCaptureEvent;
   const showActivePlayerIndicator =
-    settings.flashActivePlayes && hasActivePlayers;
+    settings.flashActivePlayers && hasActivePlayers;
   const activePlayerRadiusMultiplier = showActivePlayerIndicator ? 1.25 : 1;
   const radius =
     ((highlighted ? baseRadius * 3 : baseRadius) *

--- a/src/components/ui/StarSystem.tsx
+++ b/src/components/ui/StarSystem.tsx
@@ -1,5 +1,5 @@
 import { memo, useEffect, useRef, useState } from 'react';
-import { Circle, Image as KonvaImage } from 'react-konva';
+import { Circle, Group, Image as KonvaImage } from 'react-konva';
 import Konva from 'konva';
 import { findFaction, openInNewTab } from '../helpers';
 import pirateIconUrl from '../../assets/joli-rouge-icon.svg';
@@ -47,7 +47,7 @@ const loadCaptureEventIconImage = makeIconLoader(captureEventIconUrl);
 interface StarSystemProps {
   system: DisplayStarSystemType;
   factions: FactionDataType;
-  zoomScaleFactor: number;
+  scaleRef: React.RefObject<number>;
   settings: Settings;
   showTooltip: (
     text: string,
@@ -67,7 +67,7 @@ interface StarSystemProps {
 
 const StarSystem: React.FC<StarSystemProps> = ({
   system,
-  zoomScaleFactor,
+  scaleRef,
   factions,
   settings,
   showTooltip,
@@ -112,11 +112,10 @@ const StarSystem: React.FC<StarSystemProps> = ({
     settings.flashActivePlayers && hasActivePlayers;
   const activePlayerRadiusMultiplier = showActivePlayerIndicator ? 1.25 : 1;
   const radius =
-    ((highlighted ? baseRadius * 3 : baseRadius) *
-      activePlayerRadiusMultiplier) /
-    zoomScaleFactor;
+    (highlighted ? baseRadius * 3 : baseRadius) * activePlayerRadiusMultiplier;
   const centerX = Number(system.posX);
   const centerY = -Number(system.posY);
+  const groupRef = useRef<Konva.Group>(null);
   const circleOpacity = showActivePlayerIndicator
     ? Math.min(1, opacity + 0.25)
     : opacity;
@@ -188,6 +187,25 @@ const StarSystem: React.FC<StarSystemProps> = ({
       .catch(() => { if (!cancelled) setCaptureEventIconImage(null); });
     return () => { cancelled = true; };
   }, [hasCaptureEvent]);
+
+  // Keep the group scale in sync with the stage zoom imperatively so zoom events
+  // don't trigger React re-renders for every visible StarSystem.
+  useEffect(() => {
+    const group = groupRef.current;
+    if (!group) return;
+
+    let lastApplied = -1;
+
+    const animation = new Konva.Animation(() => {
+      const s = 1 / Math.min(scaleRef.current ?? 1, 1);
+      if (s === lastApplied) return false;
+      lastApplied = s;
+      group.scale({ x: s, y: s });
+    }, group.getLayer());
+
+    animation.start();
+    return () => animation.stop();
+  }, [scaleRef]);
 
   useEffect(() => {
     if (
@@ -310,13 +328,20 @@ const StarSystem: React.FC<StarSystemProps> = ({
     };
   };
 
+  const initialGroupScale = 1 / Math.min(scaleRef.current ?? 1, 1);
+
   return (
-    <>
+    <Group
+      ref={groupRef}
+      x={centerX}
+      y={centerY}
+      scale={{ x: initialGroupScale, y: initialGroupScale }}
+    >
       {isInsurrectionLike && (
         <Circle
           ref={insurrectGlowRef}
-          x={centerX}
-          y={centerY}
+          x={0}
+          y={0}
           radius={insurrectGlowRadius}
           fillRadialGradientStartPoint={{ x: 0, y: 0 }}
           fillRadialGradientStartRadius={0}
@@ -339,8 +364,8 @@ const StarSystem: React.FC<StarSystemProps> = ({
       {isInsurrectionLike && (
         <Circle
           ref={insurrectPulseRef}
-          x={centerX}
-          y={centerY}
+          x={0}
+          y={0}
           radius={insurrectPulseRadius}
           fillRadialGradientStartPoint={{ x: 0, y: 0 }}
           fillRadialGradientStartRadius={0}
@@ -357,8 +382,8 @@ const StarSystem: React.FC<StarSystemProps> = ({
       )}
       {showActivePlayerIndicator && (
         <Circle
-          x={centerX}
-          y={centerY}
+          x={0}
+          y={0}
           fill={system.factionColour}
           radius={haloRadius}
           opacity={haloOpacity}
@@ -367,8 +392,8 @@ const StarSystem: React.FC<StarSystemProps> = ({
       )}
       {showActivePlayerIndicator && (
         <Circle
-          x={centerX}
-          y={centerY}
+          x={0}
+          y={0}
           radius={radius}
           stroke="#ffffff"
           strokeWidth={Math.max(0.2, radius * 0.14)}
@@ -378,8 +403,8 @@ const StarSystem: React.FC<StarSystemProps> = ({
       )}
       <Circle
         ref={systemCircleRef}
-        x={centerX}
-        y={centerY}
+        x={0}
+        y={0}
         fill={system.factionColour}
         radius={radius}
         hitStrokeWidth={3}
@@ -447,8 +472,8 @@ const StarSystem: React.FC<StarSystemProps> = ({
         <KonvaImage
           ref={pirateIconRef}
           image={pirateIconImage}
-          x={centerX}
-          y={centerY}
+          x={0}
+          y={0}
           width={pirateIconSize}
           height={pirateIconSize}
           offsetX={pirateIconSize / 2}
@@ -460,8 +485,8 @@ const StarSystem: React.FC<StarSystemProps> = ({
         <KonvaImage
           ref={holdTheLineIconRef}
           image={holdTheLineIconImage}
-          x={centerX}
-          y={centerY}
+          x={0}
+          y={0}
           width={pirateIconSize}
           height={pirateIconSize}
           offsetX={pirateIconSize / 2}
@@ -476,8 +501,8 @@ const StarSystem: React.FC<StarSystemProps> = ({
         <KonvaImage
           ref={captureEventIconRef}
           image={captureEventIconImage}
-          x={centerX}
-          y={centerY}
+          x={0}
+          y={0}
           width={pirateIconSize}
           height={pirateIconSize}
           offsetX={pirateIconSize / 2}
@@ -490,8 +515,8 @@ const StarSystem: React.FC<StarSystemProps> = ({
       )}
       {showActivePlayerIndicator && (
         <Circle
-          x={centerX - shineOffset}
-          y={centerY - shineOffset}
+          x={-shineOffset}
+          y={-shineOffset}
           radius={shineRadius}
           fillRadialGradientStartPoint={{ x: 0, y: 0 }}
           fillRadialGradientStartRadius={0}
@@ -506,7 +531,7 @@ const StarSystem: React.FC<StarSystemProps> = ({
           listening={false}
         />
       )}
-    </>
+    </Group>
   );
 };
 

--- a/tests/devStateInjector.test.ts
+++ b/tests/devStateInjector.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { applyDevStateInjection } from '../src/components/helpers/devStateInjector';
+import type { StarSystemType } from '../src/components/hooks/types';
+
+const makeSystem = (name: string, state?: StarSystemType['state']): StarSystemType => ({
+  name,
+  posX: 0,
+  posY: 0,
+  owner: 'FACTION_A',
+  factions: [],
+  sysUrl: `/system/${name}`,
+  state,
+});
+
+const mockWindow = (
+  search = '',
+  localStorageItems: Record<string, string> = {}
+) => ({
+  location: { search },
+  localStorage: {
+    getItem: (key: string) => localStorageItems[key] ?? null,
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+  },
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe('applyDevStateInjection', () => {
+  it('returns the same array reference when window is not defined', () => {
+    const systems = [makeSystem('Alpha')];
+    // In Node (vitest default env), window is naturally undefined — no stub needed
+    expect(applyDevStateInjection(systems)).toBe(systems);
+  });
+
+  it('returns the same array reference when no enabled flag is set', () => {
+    vi.stubGlobal('window', mockWindow('', {}));
+    const systems = [makeSystem('Alpha')];
+    expect(applyDevStateInjection(systems)).toBe(systems);
+  });
+
+  describe('isTruthyFlag — URL param falsy values disable injection', () => {
+    it('stateTest=false → disabled', () => {
+      vi.stubGlobal('window', mockWindow('?stateTest=false', {}));
+      const systems = [makeSystem('Alpha')];
+      expect(applyDevStateInjection(systems)).toBe(systems);
+    });
+
+    it('stateTest=0 → disabled', () => {
+      vi.stubGlobal('window', mockWindow('?stateTest=0', {}));
+      const systems = [makeSystem('Alpha')];
+      expect(applyDevStateInjection(systems)).toBe(systems);
+    });
+
+    it('stateTest=off → disabled', () => {
+      vi.stubGlobal('window', mockWindow('?stateTest=off', {}));
+      const systems = [makeSystem('Alpha')];
+      expect(applyDevStateInjection(systems)).toBe(systems);
+    });
+  });
+
+  describe('isTruthyFlag — URL param truthy values enable injection', () => {
+    const fiveSystems = () => ['Alpha', 'Beta', 'Charlie', 'Delta', 'Echo'].map(makeSystem);
+
+    it('stateTest=true → enabled', () => {
+      vi.stubGlobal('window', mockWindow('?stateTest=true', {}));
+      const result = applyDevStateInjection(fiveSystems());
+      expect(result.some((s) => s.state !== undefined)).toBe(true);
+    });
+
+    it('stateTest=1 → enabled', () => {
+      vi.stubGlobal('window', mockWindow('?stateTest=1', {}));
+      const result = applyDevStateInjection(fiveSystems());
+      expect(result.some((s) => s.state !== undefined)).toBe(true);
+    });
+
+    it('URL param key matching is case-insensitive (STATETEST=true)', () => {
+      vi.stubGlobal('window', mockWindow('?STATETEST=true', {}));
+      const result = applyDevStateInjection(fiveSystems());
+      expect(result.some((s) => s.state !== undefined)).toBe(true);
+    });
+  });
+
+  it('enables injection via localStorage when URL param is absent', () => {
+    vi.stubGlobal('window', mockWindow('', { warMapDevStateTest: 'true' }));
+    const systems = ['Alpha', 'Beta', 'Charlie', 'Delta', 'Echo'].map(makeSystem);
+    const result = applyDevStateInjection(systems);
+    expect(result.some((s) => s.state !== undefined)).toBe(true);
+  });
+
+  describe('sample preset (default)', () => {
+    it('assigns distinct state types to the first 5 systems in alphabetical order', () => {
+      vi.stubGlobal('window', mockWindow('?stateTest=true', {}));
+      const systems = ['Alpha', 'Beta', 'Charlie', 'Delta', 'Echo'].map(makeSystem);
+      const result = applyDevStateInjection(systems);
+      const byName = Object.fromEntries(result.map((s) => [s.name, s.state]));
+
+      // buildSampleOverrides: [0]=isInsurrect, [1]=hasPirateRaid, [2]=hasCaptureEvent,
+      //                        [3]=hasHoldTheLineEvent, [4]=hasPirateRaid+hasCaptureEvent
+      expect(byName['Alpha']?.isInsurrect).toBe(true);
+      expect(byName['Beta']?.hasPirateRaid).toBe(true);
+      expect(byName['Charlie']?.hasCaptureEvent).toBe(true);
+      expect(byName['Delta']?.hasHoldTheLineEvent).toBe(true);
+      expect(byName['Echo']?.hasPirateRaid).toBe(true);
+      expect(byName['Echo']?.hasCaptureEvent).toBe(true);
+    });
+
+    it('leaves systems beyond the first 5 as the same object reference (not mutated)', () => {
+      vi.stubGlobal('window', mockWindow('?stateTest=true', {}));
+      const foxtrot = makeSystem('Foxtrot');
+      // Foxtrot is 6th alphabetically — excluded from sample preset's first 5
+      const systems = [makeSystem('Alpha'), makeSystem('Beta'), makeSystem('Charlie'), makeSystem('Delta'), makeSystem('Echo'), foxtrot];
+      const result = applyDevStateInjection(systems);
+      const resultFoxtrot = result.find((s) => s.name === 'Foxtrot');
+      // Same reference means no override was applied
+      expect(resultFoxtrot).toBe(foxtrot);
+    });
+  });
+
+  describe('dense preset', () => {
+    const SYSTEMS = Array.from({ length: 13 }, (_, i) =>
+      makeSystem(`System${String(i).padStart(2, '0')}`)
+    );
+
+    it('cycles through 4 state types across the first 12 systems', () => {
+      vi.stubGlobal('window', mockWindow('?stateTest=true&statePreset=dense', {}));
+      const result = applyDevStateInjection(SYSTEMS);
+      const byName = Object.fromEntries(result.map((s) => [s.name, s.state]));
+
+      // idx % 4: 0→isInsurrect, 1→hasPirateRaid, 2→hasCaptureEvent, 3→hasHoldTheLineEvent
+      expect(byName['System00']?.isInsurrect).toBe(true);
+      expect(byName['System01']?.hasPirateRaid).toBe(true);
+      expect(byName['System02']?.hasCaptureEvent).toBe(true);
+      expect(byName['System03']?.hasHoldTheLineEvent).toBe(true);
+      expect(byName['System04']?.isInsurrect).toBe(true);
+      expect(byName['System08']?.isInsurrect).toBe(true);
+    });
+
+    it('leaves the 13th system (index 12, beyond first 12) without dense preset state', () => {
+      vi.stubGlobal('window', mockWindow('?stateTest=true&statePreset=dense', {}));
+      const result = applyDevStateInjection(SYSTEMS);
+      const last = result.find((s) => s.name === 'System12');
+      expect(last?.state).toBeUndefined();
+    });
+  });
+
+  describe('named system overrides', () => {
+    it('applies isInsurrect to known insurrection systems', () => {
+      vi.stubGlobal('window', mockWindow('?stateTest=true', {}));
+      const systems = [makeSystem('Tainjin'), makeSystem('Millerton')];
+      const result = applyDevStateInjection(systems);
+      const byName = Object.fromEntries(result.map((s) => [s.name, s.state]));
+      expect(byName['Tainjin']?.isInsurrect).toBe(true);
+      expect(byName['Millerton']?.isInsurrect).toBe(true);
+    });
+
+    it('applies hasPirateRaid to known pirate raid systems', () => {
+      vi.stubGlobal('window', mockWindow('?stateTest=true', {}));
+      const systems = [makeSystem('Bougie'), makeSystem('Naco')];
+      const result = applyDevStateInjection(systems);
+      const byName = Object.fromEntries(result.map((s) => [s.name, s.state]));
+      expect(byName['Bougie']?.hasPirateRaid).toBe(true);
+      expect(byName['Naco']?.hasPirateRaid).toBe(true);
+    });
+
+    it('applies hasHoldTheLineEvent to the known hold-the-line system', () => {
+      vi.stubGlobal('window', mockWindow('?stateTest=true', {}));
+      const systems = [makeSystem('Port Vail (The Rack 3050+)')];
+      const result = applyDevStateInjection(systems);
+      expect(result[0].state?.hasHoldTheLineEvent).toBe(true);
+    });
+
+    it('applies hasCaptureEvent to the known capture event system', () => {
+      vi.stubGlobal('window', mockWindow('?stateTest=true', {}));
+      const systems = [makeSystem('Wiltshire')];
+      const result = applyDevStateInjection(systems);
+      expect(result[0].state?.hasCaptureEvent).toBe(true);
+    });
+
+    it('matches system names case-insensitively', () => {
+      vi.stubGlobal('window', mockWindow('?stateTest=true', {}));
+      // DEV_INSURRECTION_SYSTEMS has 'Tainjin'; provide it lowercased
+      const systems = [makeSystem('tainjin')];
+      const result = applyDevStateInjection(systems);
+      expect(result[0].state?.isInsurrect).toBe(true);
+    });
+  });
+
+  describe('custom localStorage overrides', () => {
+    it('applies custom overrides and they take priority over preset', () => {
+      const customOverrides = JSON.stringify({ Alpha: { hasPirateRaid: true } });
+      vi.stubGlobal('window', mockWindow('?stateTest=true', {
+        warMapDevStateOverrides: customOverrides,
+      }));
+      const systems = ['Alpha', 'Beta', 'Charlie', 'Delta', 'Echo'].map(makeSystem);
+      const result = applyDevStateInjection(systems);
+      const alpha = result.find((s) => s.name === 'Alpha');
+      expect(alpha?.state?.hasPirateRaid).toBe(true);
+    });
+
+    it('invalid JSON in localStorage is silently ignored without throwing', () => {
+      vi.stubGlobal('window', mockWindow('?stateTest=true', {
+        warMapDevStateOverrides: '{{{not-valid-json',
+      }));
+      const systems = ['Alpha', 'Beta', 'Charlie', 'Delta', 'Echo'].map(makeSystem);
+      expect(() => applyDevStateInjection(systems)).not.toThrow();
+    });
+
+    it('rejects override entries with non-boolean state values (isStateOverrideMap guard)', () => {
+      const badOverrides = JSON.stringify({ Alpha: { isInsurrect: 'yes' } });
+      vi.stubGlobal('window', mockWindow('?stateTest=true', {
+        warMapDevStateOverrides: badOverrides,
+      }));
+      const systems = [makeSystem('Alpha')];
+      expect(() => applyDevStateInjection(systems)).not.toThrow();
+    });
+
+    it('rejects override entries that are not objects', () => {
+      const badOverrides = JSON.stringify({ Alpha: 'insurrect' });
+      vi.stubGlobal('window', mockWindow('?stateTest=true', {
+        warMapDevStateOverrides: badOverrides,
+      }));
+      const systems = [makeSystem('Alpha')];
+      expect(() => applyDevStateInjection(systems)).not.toThrow();
+    });
+  });
+
+  describe('state merging', () => {
+    it('merges injected state onto existing state without dropping prior keys', () => {
+      vi.stubGlobal('window', mockWindow('?stateTest=true', {}));
+      // Alpha starts with hasPirateRaid; sample preset injects isInsurrect onto it
+      const systems = [
+        makeSystem('Alpha', { hasPirateRaid: true }),
+        makeSystem('Beta'),
+        makeSystem('Charlie'),
+        makeSystem('Delta'),
+        makeSystem('Echo'),
+      ];
+      const result = applyDevStateInjection(systems);
+      const alpha = result.find((s) => s.name === 'Alpha')!;
+      // { ...system.state, ...injected } → both keys survive
+      expect(alpha.state?.isInsurrect).toBe(true);
+      expect(alpha.state?.hasPirateRaid).toBe(true);
+    });
+
+    it('returns the same object reference for unmatched systems', () => {
+      vi.stubGlobal('window', mockWindow('?stateTest=true', {}));
+      const unmatched = makeSystem('ZzNoOverrideMatch');
+      // Put unmatched 6th so sample preset's first 5 are the others
+      const systems = [
+        makeSystem('Alpha'),
+        makeSystem('Beta'),
+        makeSystem('Charlie'),
+        makeSystem('Delta'),
+        makeSystem('Echo'),
+        unmatched,
+      ];
+      const result = applyDevStateInjection(systems);
+      const resultUnmatched = result.find((s) => s.name === 'ZzNoOverrideMatch')!;
+      expect(resultUnmatched).toBe(unmatched);
+    });
+  });
+});

--- a/tests/perf.bench.ts
+++ b/tests/perf.bench.ts
@@ -1,0 +1,366 @@
+/**
+ * Performance benchmarks for the hot paths in GalaxyMap.
+ *
+ * Run with:  yarn bench
+ *
+ * Each describe block pairs a "current" implementation against a candidate
+ * optimisation so the output directly shows whether the change is worth making.
+ */
+import { bench, describe } from 'vitest';
+import { buildFactionFilterOptions } from '../src/components/GalaxyMap/gm.selectors';
+import type { DisplayStarSystemType } from '../src/components/hooks/types';
+
+// ---------------------------------------------------------------------------
+// Shared test-data helpers
+// ---------------------------------------------------------------------------
+
+type ViewTransform = { scale: number; position: { x: number; y: number } };
+type StageSize = { width: number; height: number };
+type Bounds = { left: number; right: number; top: number; bottom: number };
+
+function makeSystem(
+  name: string,
+  posX: number,
+  posY: number,
+  owner = 'Faction_A'
+): DisplayStarSystemType {
+  return {
+    name,
+    posX,
+    posY,
+    owner,
+    factions: [],
+    id: `${name}-${posX}-${posY}`,
+    factionColour: '#ff0000',
+    factionName: 'Faction A',
+    normalizedName: name.toLowerCase(),
+    isCapital: false,
+  };
+}
+
+/** Spread N systems uniformly across the coordinate range [-range, +range]. */
+function makeSystems(n: number, range = 500): DisplayStarSystemType[] {
+  const systems: DisplayStarSystemType[] = [];
+  const owners = ['Faction_A', 'Faction_B', 'Faction_C', 'Faction_D'];
+  for (let i = 0; i < n; i++) {
+    const posX = ((i / n) * 2 - 1) * range;
+    const posY = (((i * 7) % n) / n * 2 - 1) * range;
+    systems.push(
+      makeSystem(`System_${i}`, posX, posY, owners[i % owners.length])
+    );
+  }
+  return systems;
+}
+
+/**
+ * Pre-converted variant: numeric x/y stored alongside posX/posY.
+ * Built in a single pass to avoid double-spread hidden-class fragmentation.
+ * This mirrors what projectSystemData would produce if it included x/y.
+ */
+type SystemWithNumericCoords = DisplayStarSystemType & { x: number; y: number };
+
+function makeSystemsPreConverted(
+  n: number,
+  range = 500
+): SystemWithNumericCoords[] {
+  const systems: SystemWithNumericCoords[] = [];
+  const owners = ['Faction_A', 'Faction_B', 'Faction_C', 'Faction_D'];
+  for (let i = 0; i < n; i++) {
+    const posX = ((i / n) * 2 - 1) * range;
+    const posY = (((i * 7) % n) / n * 2 - 1) * range;
+    const owner = owners[i % owners.length];
+    systems.push({
+      name: `System_${i}`,
+      posX,
+      posY,
+      owner,
+      factions: [],
+      id: `System_${i}-${posX}-${posY}`,
+      factionColour: '#ff0000',
+      factionName: 'Faction A',
+      normalizedName: `system_${i}`,
+      isCapital: false,
+      x: posX,
+      y: -posY,
+    });
+  }
+  return systems;
+}
+
+function getViewportBounds(
+  stageSize: StageSize,
+  view: ViewTransform,
+  screenMargin = 120
+): Bounds {
+  if (stageSize.width <= 0 || stageSize.height <= 0) {
+    return {
+      left: -Infinity,
+      right: Infinity,
+      top: -Infinity,
+      bottom: Infinity,
+    };
+  }
+  const margin = Math.max(screenMargin / view.scale, 1);
+  return {
+    left: (0 - view.position.x) / view.scale - margin,
+    top: (0 - view.position.y) / view.scale - margin,
+    right: (stageSize.width - view.position.x) / view.scale + margin,
+    bottom: (stageSize.height - view.position.y) / view.scale + margin,
+  };
+}
+
+// Viewport scenarios
+const STAGE: StageSize = { width: 1920, height: 1080 };
+
+// Zoomed in: small window, ~10% of systems visible
+const VIEW_TIGHT: ViewTransform = { scale: 5, position: { x: 960, y: 540 } };
+// Medium zoom: ~40% visible
+const VIEW_MID: ViewTransform = { scale: 1.5, position: { x: 960, y: 540 } };
+// Zoomed out: full map visible
+const VIEW_WIDE: ViewTransform = { scale: 0.5, position: { x: 960, y: 540 } };
+
+const SYSTEMS_2K = makeSystems(2000);
+const SYSTEMS_2K_PRE = makeSystemsPreConverted(2000);
+
+// ---------------------------------------------------------------------------
+// 1. visibleSystems — current vs pre-converted coords
+// ---------------------------------------------------------------------------
+
+describe('visibleSystems filter — tight zoom (~10% visible)', () => {
+  const viewport = getViewportBounds(STAGE, VIEW_TIGHT);
+  const selectedFactionsSet = new Set<string>();
+
+  bench('current: Number(posX) per iteration', () => {
+    SYSTEMS_2K.filter((s) => {
+      const x = Number(s.posX);
+      const y = -Number(s.posY);
+      if (x < viewport.left || x > viewport.right) return false;
+      if (y < viewport.top || y > viewport.bottom) return false;
+      return !selectedFactionsSet.size || selectedFactionsSet.has(s.factionName);
+    });
+  });
+
+  bench('optimised: pre-converted x/y fields', () => {
+    SYSTEMS_2K_PRE.filter((s) => {
+      if (s.x < viewport.left || s.x > viewport.right) return false;
+      if (s.y < viewport.top || s.y > viewport.bottom) return false;
+      return !selectedFactionsSet.size || selectedFactionsSet.has(s.factionName);
+    });
+  });
+});
+
+describe('visibleSystems filter — medium zoom (~40% visible)', () => {
+  const viewport = getViewportBounds(STAGE, VIEW_MID);
+  const selectedFactionsSet = new Set<string>();
+
+  bench('current: Number(posX) per iteration', () => {
+    SYSTEMS_2K.filter((s) => {
+      const x = Number(s.posX);
+      const y = -Number(s.posY);
+      if (x < viewport.left || x > viewport.right) return false;
+      if (y < viewport.top || y > viewport.bottom) return false;
+      return !selectedFactionsSet.size || selectedFactionsSet.has(s.factionName);
+    });
+  });
+
+  bench('optimised: pre-converted x/y fields', () => {
+    SYSTEMS_2K_PRE.filter((s) => {
+      if (s.x < viewport.left || s.x > viewport.right) return false;
+      if (s.y < viewport.top || s.y > viewport.bottom) return false;
+      return !selectedFactionsSet.size || selectedFactionsSet.has(s.factionName);
+    });
+  });
+});
+
+describe('visibleSystems filter — wide zoom (full map visible)', () => {
+  const viewport = getViewportBounds(STAGE, VIEW_WIDE);
+  const selectedFactionsSet = new Set<string>();
+
+  bench('current: Number(posX) per iteration', () => {
+    SYSTEMS_2K.filter((s) => {
+      const x = Number(s.posX);
+      const y = -Number(s.posY);
+      if (x < viewport.left || x > viewport.right) return false;
+      if (y < viewport.top || y > viewport.bottom) return false;
+      return !selectedFactionsSet.size || selectedFactionsSet.has(s.factionName);
+    });
+  });
+
+  bench('optimised: pre-converted x/y fields', () => {
+    SYSTEMS_2K_PRE.filter((s) => {
+      if (s.x < viewport.left || s.x > viewport.right) return false;
+      if (s.y < viewport.top || s.y > viewport.bottom) return false;
+      return !selectedFactionsSet.size || selectedFactionsSet.has(s.factionName);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Faction filter — checking whether Set.has is actually fast at scale
+// ---------------------------------------------------------------------------
+
+describe('visibleSystems — faction filter overhead', () => {
+  const viewport = getViewportBounds(STAGE, VIEW_WIDE);
+
+  bench('no faction filter (selectedFactions empty)', () => {
+    const set = new Set<string>();
+    SYSTEMS_2K_PRE.filter((s) => {
+      if (s.x < viewport.left || s.x > viewport.right) return false;
+      if (s.y < viewport.top || s.y > viewport.bottom) return false;
+      return !set.size || set.has(s.factionName);
+    });
+  });
+
+  bench('single faction selected (Set.has every iteration)', () => {
+    const set = new Set(['Faction A']);
+    SYSTEMS_2K_PRE.filter((s) => {
+      if (s.x < viewport.left || s.x > viewport.right) return false;
+      if (s.y < viewport.top || s.y > viewport.bottom) return false;
+      return !set.size || set.has(s.factionName);
+    });
+  });
+
+  bench('three factions selected', () => {
+    const set = new Set(['Faction A', 'Faction B', 'Faction C']);
+    SYSTEMS_2K_PRE.filter((s) => {
+      if (s.x < viewport.left || s.x > viewport.right) return false;
+      if (s.y < viewport.top || s.y > viewport.bottom) return false;
+      return !set.size || set.has(s.factionName);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. JSX element construction — cost of the renderedSystems map
+//
+// React.createElement is called for every visible system on every pan frame,
+// even when StarSystem is memoized (memo prevents re-render, not element
+// construction). This measures that fixed overhead.
+// ---------------------------------------------------------------------------
+
+// Minimal stand-in that matches the shape StarSystem receives.
+type FakeProps = {
+  key: string;
+  system: DisplayStarSystemType;
+  zoomScaleFactor: number;
+  factions: object;
+  highlighted: boolean;
+  opacity: number;
+};
+
+const stableShowTooltip = () => {};
+const stableHideTooltip = () => {};
+const stableTooltipRef = { current: false };
+const stableTouchRef = { current: null };
+const stableFactions = {};
+
+function buildRenderedSystemsPropsOldKey(
+  systems: DisplayStarSystemType[],
+  zoomFactor: number
+): FakeProps[] {
+  return systems.map((s) => ({
+    key: `${s.name}-${s.posX}-${s.posY}-${s.owner}`,
+    system: s,
+    zoomScaleFactor: zoomFactor,
+    factions: stableFactions,
+    settings: { flashActivePlayers: true },
+    showTooltip: stableShowTooltip,
+    hideTooltip: stableHideTooltip,
+    tooltipVisibleRef: stableTooltipRef,
+    touchedSystemNameRef: stableTouchRef,
+    highlighted: false,
+    opacity: 1,
+  }));
+}
+
+// Uses the pre-computed system.id field (name+posX+posY, built once at projection time).
+function buildRenderedSystemsProps(
+  systems: DisplayStarSystemType[],
+  zoomFactor: number
+): FakeProps[] {
+  return systems.map((s) => ({
+    key: s.id,
+    system: s,
+    zoomScaleFactor: zoomFactor,
+    factions: stableFactions,
+    settings: { flashActivePlayers: true },
+    showTooltip: stableShowTooltip,
+    hideTooltip: stableHideTooltip,
+    tooltipVisibleRef: stableTooltipRef,
+    touchedSystemNameRef: stableTouchRef,
+    highlighted: false,
+    opacity: 1,
+  }));
+}
+
+const VISIBLE_800 = SYSTEMS_2K.slice(0, 800);
+
+describe('renderedSystems — JSX props construction (pan frame cost)', () => {
+  bench('800 systems, composite key (before)', () => {
+    buildRenderedSystemsPropsOldKey(VISIBLE_800, 1);
+  });
+
+  bench('800 systems, system.id key (after)', () => {
+    buildRenderedSystemsProps(VISIBLE_800, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. buildFactionFilterOptions — one-time on data load
+// ---------------------------------------------------------------------------
+
+const FACTIONS_DICT = {
+  Faction_A: { prettyName: 'Faction A', colour: '#f00' },
+  Faction_B: { prettyName: 'Faction B', colour: '#0f0' },
+  Faction_C: { prettyName: 'Faction C', colour: '#00f' },
+  Faction_D: { prettyName: 'Faction D', colour: '#ff0' },
+};
+
+describe('buildFactionFilterOptions', () => {
+  bench('2 000 systems, 4 factions', () => {
+    buildFactionFilterOptions(SYSTEMS_2K, FACTIONS_DICT);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. projectSystemData equivalent — coord coercion + faction lookup
+// ---------------------------------------------------------------------------
+
+const RAW_SYSTEMS = SYSTEMS_2K.map((s) => ({
+  name: s.name,
+  posX: s.posX,
+  posY: s.posY,
+  owner: s.owner,
+  factions: [],
+}));
+
+describe('projectSystemData — data projection on load', () => {
+  bench('current: no x/y in projection', () => {
+    RAW_SYSTEMS.map((s) => {
+      const faction = FACTIONS_DICT[s.owner as keyof typeof FACTIONS_DICT];
+      return {
+        ...s,
+        isCapital: false,
+        factionColour: faction?.colour ?? 'gray',
+        factionName: faction?.prettyName ?? s.owner,
+        normalizedName: s.name.toLowerCase(),
+      };
+    });
+  });
+
+  // Adds x/y to the same single spread — mirrors the actual code change cost.
+  bench('with x/y in same spread', () => {
+    RAW_SYSTEMS.map((s) => {
+      const faction = FACTIONS_DICT[s.owner as keyof typeof FACTIONS_DICT];
+      return {
+        ...s,
+        isCapital: false,
+        factionColour: faction?.colour ?? 'gray',
+        factionName: faction?.prettyName ?? s.owner,
+        normalizedName: s.name.toLowerCase(),
+        x: Number(s.posX),
+        y: -Number(s.posY),
+      };
+    });
+  });
+});

--- a/tests/useGalaxyViewport.test.ts
+++ b/tests/useGalaxyViewport.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+
+const SCALE_BY = 1.25;
+const MIN_SCALE = 0.2;
+const MAX_SCALE = 25;
+
+// Wheel zoom math extracted from useGalaxyViewport.onWheel.
+// Returns the new scale and the updated stage position that keeps the
+// world point under the pointer fixed.
+const calcWheelZoom = (
+  deltaY: number,
+  oldScale: number,
+  pointerX: number,
+  pointerY: number,
+  stageX: number,
+  stageY: number,
+  minScale = MIN_SCALE,
+  maxScale = MAX_SCALE
+) => {
+  let newScale = deltaY > 0 ? oldScale / SCALE_BY : oldScale * SCALE_BY;
+  newScale = Math.max(minScale, Math.min(maxScale, newScale));
+
+  const mousePointTo = {
+    x: (pointerX - stageX) / oldScale,
+    y: (pointerY - stageY) / oldScale,
+  };
+
+  const newPosition = {
+    x: pointerX - mousePointTo.x * newScale,
+    y: pointerY - mousePointTo.y * newScale,
+  };
+
+  return { newScale, newPosition };
+};
+
+describe('useGalaxyViewport wheel zoom math', () => {
+  describe('scale direction', () => {
+    it('zooms in (scale increases) when deltaY < 0', () => {
+      const { newScale } = calcWheelZoom(-1, 1, 0, 0, 0, 0);
+      expect(newScale).toBeCloseTo(SCALE_BY);
+    });
+
+    it('zooms out (scale decreases) when deltaY > 0', () => {
+      const { newScale } = calcWheelZoom(1, 1, 0, 0, 0, 0);
+      expect(newScale).toBeCloseTo(1 / SCALE_BY);
+    });
+
+    it('each zoom step multiplies/divides by the fixed SCALE_BY factor (1.25)', () => {
+      const { newScale: zoomedIn } = calcWheelZoom(-1, 2, 0, 0, 0, 0);
+      expect(zoomedIn).toBeCloseTo(2 * SCALE_BY);
+
+      const { newScale: zoomedOut } = calcWheelZoom(1, 2, 0, 0, 0, 0);
+      expect(zoomedOut).toBeCloseTo(2 / SCALE_BY);
+    });
+  });
+
+  describe('scale clamping', () => {
+    it('does not exceed MAX_SCALE when zooming in at the limit', () => {
+      const { newScale } = calcWheelZoom(-1, MAX_SCALE, 0, 0, 0, 0);
+      expect(newScale).toBe(MAX_SCALE);
+    });
+
+    it('does not go below MIN_SCALE when zooming out at the limit', () => {
+      const { newScale } = calcWheelZoom(1, MIN_SCALE, 0, 0, 0, 0);
+      expect(newScale).toBe(MIN_SCALE);
+    });
+  });
+
+  describe('pointer-centred zoom invariant', () => {
+    it('keeps the world point under the pointer stable after zoom', () => {
+      const pointerX = 400;
+      const pointerY = 300;
+      const stageX = 0;
+      const stageY = 0;
+      const oldScale = 1;
+
+      const { newScale, newPosition } = calcWheelZoom(
+        -1,
+        oldScale,
+        pointerX,
+        pointerY,
+        stageX,
+        stageY
+      );
+
+      const worldXBefore = (pointerX - stageX) / oldScale;
+      const worldYBefore = (pointerY - stageY) / oldScale;
+      const worldXAfter = (pointerX - newPosition.x) / newScale;
+      const worldYAfter = (pointerY - newPosition.y) / newScale;
+
+      expect(worldXAfter).toBeCloseTo(worldXBefore);
+      expect(worldYAfter).toBeCloseTo(worldYBefore);
+    });
+
+    it('invariant holds when the stage is already panned', () => {
+      const { newScale, newPosition } = calcWheelZoom(-1, 1, 400, 300, -200, -150);
+
+      const worldXBefore = (400 - -200) / 1;
+      const worldXAfter = (400 - newPosition.x) / newScale;
+
+      expect(worldXAfter).toBeCloseTo(worldXBefore);
+    });
+
+    it('invariant holds across a range of existing scale values', () => {
+      for (const oldScale of [0.5, 1, 2, 5, 10]) {
+        const { newScale, newPosition } = calcWheelZoom(
+          -1,
+          oldScale,
+          400,
+          300,
+          100,
+          100
+        );
+        const worldXBefore = (400 - 100) / oldScale;
+        const worldXAfter = (400 - newPosition.x) / newScale;
+        expect(worldXAfter).toBeCloseTo(worldXBefore, 8);
+      }
+    });
+
+    it('zoom-out invariant holds (deltaY > 0)', () => {
+      const { newScale, newPosition } = calcWheelZoom(1, 2, 500, 400, 50, 50);
+
+      const worldXBefore = (500 - 50) / 2;
+      const worldXAfter = (500 - newPosition.x) / newScale;
+
+      expect(worldXAfter).toBeCloseTo(worldXBefore);
+    });
+  });
+
+  describe('position update', () => {
+    it('position stays at pointer when stage origin equals pointer', () => {
+      // If stage is at (400, 300) and pointer is at (400, 300), world point = (0, 0)
+      // After zoom, new position should keep (0, 0) under (400, 300)
+      const { newPosition } = calcWheelZoom(-1, 1, 400, 300, 400, 300);
+      expect(newPosition.x).toBeCloseTo(400);
+      expect(newPosition.y).toBeCloseTo(300);
+    });
+  });
+});

--- a/tests/usePinchZoom.test.ts
+++ b/tests/usePinchZoom.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from 'vitest';
+
+const JITTER_THRESHOLD = 0.02;
+const FRAME_CLAMP_MIN = 0.9;
+const FRAME_CLAMP_MAX = 1.1;
+const MIN_SCALE = 0.2;
+const MAX_SCALE = 25;
+
+// Scale math extracted from usePinchZoom.onTouchMove (inside the rAF callback).
+// Returns { skipped: true } when the delta is within the jitter deadband.
+const calcPinchScale = (
+  newDistance: number,
+  lastDistance: number,
+  oldScale: number,
+  minScale = MIN_SCALE,
+  maxScale = MAX_SCALE
+): { skipped: boolean; newScale: number } => {
+  let scaleBy = newDistance / lastDistance;
+
+  if (Math.abs(1 - scaleBy) < JITTER_THRESHOLD) {
+    return { skipped: true, newScale: oldScale };
+  }
+
+  scaleBy = Math.max(FRAME_CLAMP_MIN, Math.min(FRAME_CLAMP_MAX, scaleBy));
+  const newScale = Math.max(minScale, Math.min(maxScale, oldScale * scaleBy));
+
+  return { skipped: false, newScale };
+};
+
+// Position math extracted from usePinchZoom.onTouchMove.
+// Keeps the world point under the pinch centre fixed after the scale change.
+const calcPinchPosition = (
+  pinchCenterX: number,
+  pinchCenterY: number,
+  stageX: number,
+  stageY: number,
+  stageScale: number,
+  newScale: number
+) => {
+  const worldPos = {
+    x: (pinchCenterX - stageX) / stageScale,
+    y: (pinchCenterY - stageY) / stageScale,
+  };
+  return {
+    x: pinchCenterX - worldPos.x * newScale,
+    y: pinchCenterY - worldPos.y * newScale,
+  };
+};
+
+describe('usePinchZoom scale math', () => {
+  describe('jitter deadband', () => {
+    it('skips updates within the ±0.02 threshold (ratio ≈ 0.99)', () => {
+      // 100/101 ≈ 0.99 → |1 - 0.99| = 0.0099 < 0.02 → skip
+      expect(calcPinchScale(100, 101, 1).skipped).toBe(true);
+    });
+
+    it('skips updates within the ±0.02 threshold (ratio ≈ 1.01)', () => {
+      // 101/100 = 1.01 → |1 - 1.01| = 0.01 < 0.02 → skip
+      expect(calcPinchScale(101, 100, 1).skipped).toBe(true);
+    });
+
+    it('processes updates outside the threshold (ratio = 1.2)', () => {
+      // 120/100 = 1.2 → |1 - 1.2| = 0.2 ≥ 0.02 → process
+      expect(calcPinchScale(120, 100, 1).skipped).toBe(false);
+    });
+
+    it('processes updates outside the threshold (ratio = 0.8)', () => {
+      expect(calcPinchScale(80, 100, 1).skipped).toBe(false);
+    });
+
+    it('exactly 0.02 delta is NOT skipped (strict less-than check)', () => {
+      // ratio = 0.98 → |1 - 0.98| = 0.02, not < 0.02 → processed
+      expect(calcPinchScale(98, 100, 1).skipped).toBe(false);
+    });
+  });
+
+  describe('per-frame scale clamp', () => {
+    it('clamps large pinch-out (ratio 2.0) to FRAME_CLAMP_MAX of 1.1', () => {
+      const { newScale } = calcPinchScale(200, 100, 1);
+      expect(newScale).toBeCloseTo(1.1);
+    });
+
+    it('clamps large pinch-in (ratio 0.25) to FRAME_CLAMP_MIN of 0.9', () => {
+      const { newScale } = calcPinchScale(50, 200, 1);
+      expect(newScale).toBeCloseTo(0.9);
+    });
+
+    it('moderate pinch-out (ratio 1.05) is not clamped', () => {
+      const { newScale } = calcPinchScale(105, 100, 1);
+      expect(newScale).toBeCloseTo(1.05);
+    });
+
+    it('accumulates zoom correctly across multiple frames at max step', () => {
+      let scale = 1;
+      for (let i = 0; i < 10; i++) {
+        const result = calcPinchScale(110, 100, scale);
+        scale = result.newScale;
+      }
+      expect(scale).toBeCloseTo(1.1 ** 10, 5);
+    });
+  });
+
+  describe('min/max scale bounds', () => {
+    it('does not exceed MAX_SCALE when already at the ceiling', () => {
+      const { newScale } = calcPinchScale(200, 100, MAX_SCALE);
+      expect(newScale).toBe(MAX_SCALE);
+    });
+
+    it('does not go below MIN_SCALE when already at the floor', () => {
+      const { newScale } = calcPinchScale(50, 200, MIN_SCALE);
+      expect(newScale).toBe(MIN_SCALE);
+    });
+
+    it('approaches MAX_SCALE asymptotically but never exceeds it', () => {
+      let scale = MAX_SCALE * 0.9;
+      for (let i = 0; i < 20; i++) {
+        const result = calcPinchScale(110, 100, scale);
+        scale = result.newScale;
+        expect(scale).toBeLessThanOrEqual(MAX_SCALE);
+      }
+    });
+  });
+});
+
+describe('usePinchZoom position math', () => {
+  it('keeps the world point under the pinch centre fixed after scale change', () => {
+    const pinchCenterX = 400;
+    const pinchCenterY = 300;
+    const stageX = 0;
+    const stageY = 0;
+    const stageScale = 1;
+    const newScale = 1.1;
+
+    const newPos = calcPinchPosition(
+      pinchCenterX,
+      pinchCenterY,
+      stageX,
+      stageY,
+      stageScale,
+      newScale
+    );
+
+    const worldXBefore = (pinchCenterX - stageX) / stageScale;
+    const worldYBefore = (pinchCenterY - stageY) / stageScale;
+    const worldXAfter = (pinchCenterX - newPos.x) / newScale;
+    const worldYAfter = (pinchCenterY - newPos.y) / newScale;
+
+    expect(worldXAfter).toBeCloseTo(worldXBefore);
+    expect(worldYAfter).toBeCloseTo(worldYBefore);
+  });
+
+  it('invariant holds when the stage is already panned and scaled', () => {
+    const newPos = calcPinchPosition(300, 200, -100, -80, 2, 2.2);
+
+    const worldXBefore = (300 - -100) / 2;
+    const worldXAfter = (300 - newPos.x) / 2.2;
+
+    expect(worldXAfter).toBeCloseTo(worldXBefore);
+  });
+
+  it('invariant holds for a pinch-out (new scale larger) and pinch-in (new scale smaller)', () => {
+    for (const [stageScale, newScale] of [
+      [1, 1.1],
+      [2, 1.8],
+      [0.5, 0.55],
+    ]) {
+      const newPos = calcPinchPosition(500, 400, 100, 50, stageScale, newScale);
+      const worldXBefore = (500 - 100) / stageScale;
+      const worldXAfter = (500 - newPos.x) / newScale;
+      expect(worldXAfter).toBeCloseTo(worldXBefore, 8);
+    }
+  });
+
+  it('position is unchanged when new scale equals stage scale (no-op zoom)', () => {
+    const stageX = 100;
+    const stageY = 80;
+    const scale = 2;
+    const newPos = calcPinchPosition(400, 300, stageX, stageY, scale, scale);
+    expect(newPos.x).toBeCloseTo(stageX);
+    expect(newPos.y).toBeCloseTo(stageY);
+  });
+});

--- a/tests/useTooltip.test.ts
+++ b/tests/useTooltip.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+
+// Core coordinate math from useTooltip.showTooltip.
+// When stageX/Y are provided the pointer is in screen space and must be
+// converted to stage-local space; without them the pointer is already local.
+const calcTooltipPosition = (
+  pointerX: number,
+  pointerY: number,
+  scale: number,
+  stageX?: number,
+  stageY?: number
+) => ({
+  x: stageX !== undefined ? (pointerX - stageX) / scale : pointerX,
+  y: stageY !== undefined ? (pointerY - stageY) / scale : pointerY,
+});
+
+describe('useTooltip coordinate math', () => {
+  it('uses raw pointer coords when stage offsets are not provided', () => {
+    const pos = calcTooltipPosition(200, 150, 2);
+    expect(pos).toEqual({ x: 200, y: 150 });
+  });
+
+  it('converts screen pointer to stage-local coords when stage offsets are given', () => {
+    // Stage at (100, 50), scale 2, pointer at (300, 250):
+    // x = (300 - 100) / 2 = 100, y = (250 - 50) / 2 = 100
+    const pos = calcTooltipPosition(300, 250, 2, 100, 50);
+    expect(pos).toEqual({ x: 100, y: 100 });
+  });
+
+  it('divides by scale correctly when zoomed in (scale > 1)', () => {
+    const pos = calcTooltipPosition(500, 400, 4, 100, 100);
+    expect(pos.x).toBeCloseTo(100);
+    expect(pos.y).toBeCloseTo(75);
+  });
+
+  it('divides by scale correctly when zoomed out (scale < 1)', () => {
+    const pos = calcTooltipPosition(200, 150, 0.5, 0, 0);
+    expect(pos.x).toBeCloseTo(400);
+    expect(pos.y).toBeCloseTo(300);
+  });
+
+  it('returns (0, 0) when pointer is exactly at the stage origin', () => {
+    const pos = calcTooltipPosition(100, 80, 3, 100, 80);
+    expect(pos.x).toBe(0);
+    expect(pos.y).toBe(0);
+  });
+
+  it('handles negative stage offsets (stage panned right/down past origin)', () => {
+    // Stage offset −200 means the stage has been dragged right by 200px
+    const pos = calcTooltipPosition(300, 200, 1, -200, -100);
+    expect(pos.x).toBeCloseTo(500);
+    expect(pos.y).toBeCloseTo(300);
+  });
+
+  it('scale=1 leaves coords unchanged relative to stage origin', () => {
+    const pos = calcTooltipPosition(400, 300, 1, 0, 0);
+    expect(pos.x).toBe(400);
+    expect(pos.y).toBe(300);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,5 +7,30 @@ export default defineConfig(({ mode }) => {
   return {
     base: mode === 'development' ? '/' : env.VITE_BASE_URL,
     plugins: [react()],
+    build: {
+      chunkSizeWarningLimit: 700,
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (id.includes('/konva') || id.includes('/react-konva')) {
+              return 'vendor-konva';
+            }
+            if (id.includes('/@material-tailwind/')) {
+              return 'vendor-material';
+            }
+            if (id.includes('/react-select') || id.includes('/lucide-react')) {
+              return 'vendor-ui';
+            }
+            if (
+              id.includes('/node_modules/react/') ||
+              id.includes('/node_modules/react-dom/') ||
+              id.includes('/node_modules/react-router')
+            ) {
+              return 'vendor-core';
+            }
+          },
+        },
+      },
+    },
   };
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,4 +5,7 @@ export default defineConfig({
     environment: 'node',
     include: ['tests/**/*.test.ts', 'tests/**/*.test.tsx'],
   },
+  benchmark: {
+    include: ['tests/**/*.bench.ts'],
+  },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -214,6 +214,11 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz#5e13fac887f08c44f76b0ccaf3370eb00fec9bb6"
   integrity sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==
 
+"@epic-web/invariant@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@epic-web/invariant/-/invariant-1.0.0.tgz#1073e5dee6dd540410784990eb73e4acd25c9813"
+  integrity sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==
+
 "@esbuild/aix-ppc64@0.25.12":
   version "0.25.12"
   resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz#80fcbe36130e58b7670511e888b8e88a259ed76c"
@@ -1436,6 +1441,14 @@ cosmiconfig@^7.0.0:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.10.0"
+
+cross-env@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-10.1.0.tgz#cfd2a6200df9ed75bfb9cb3d7ce609c13ea21783"
+  integrity sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==
+  dependencies:
+    "@epic-web/invariant" "^1.0.0"
+    cross-spawn "^7.0.6"
 
 cross-spawn@^7.0.6:
   version "7.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1355,9 +1355,9 @@ camelcase-css@^2.0.1:
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
 caniuse-lite@^1.0.30001646:
-  version "1.0.30001662"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001662.tgz#3574b22dfec54a3f3b6787331da1040fe8e763ec"
-  integrity sha512-sgMUVwLmGseH8ZIrm1d51UbrhqMCH3jvS7gF/M6byuHOnKyLOBL7W8yz5V02OHwgLGA36o/AFhWzzh4uc5aqTA==
+  version "1.0.30001792"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz"
+  integrity sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==
 
 chai@^6.2.0:
   version "6.2.1"


### PR DESCRIPTION
## Summary

All changes are on top of the `security patches` commit. Includes everything previously merged to the now-deleted `system-state` branch, plus the build fixes.

### Bug fixes
- **Pinch zoom**: call `setZoomScaleFactor` during active pinch gesture so star dots resize mid-gesture instead of snapping at lift
- **Mobile tooltip**: replace broken `inControlBlock` state machine with prefix-based filter so faction control data is no longer silently dropped
- **Animation restart glitch**: read icon Konva nodes from refs each frame, preventing mid-animation restarts when icons load
- **SSR/window guard**: add `typeof window !== 'undefined'` guards to `positionRef` initialisation in `useGalaxyViewport`
- **Stale closure**: wrap `getDesktopLineSegments` in `useCallback` with explicit font-size deps
- **Typo**: rename `flashActivePlayes` → `flashActivePlayers` throughout
- **Icon loader factory**: collapse three near-identical loader functions into `makeIconLoader(url)` (105 lines → 32)

### Tests
44 new tests covering `devStateInjector` and the pure math in `useTooltip`, `useGalaxyViewport`, and `usePinchZoom`. Benchmark suite at `tests/perf.bench.ts` (`yarn bench`).

### React reconciliation performance
- **Stable React key**: pre-compute `system.id` in `projectSystemData` — 13× faster key construction per pan frame; removes `owner` from the key so faction captures flow as prop updates rather than unmount+remount
- **Eliminate zoom re-renders**: replace `zoomScaleFactor` prop on `StarSystem` with `scaleRef` (stable ref). `memo()` now short-circuits during zoom — previously all 800+ visible components re-rendered on every wheel tick when zoomed out. Dot sizing handled by a `Konva.Animation` per system reading `scaleRef.current` imperatively each RAF frame.

### Build
- Split 1.3 MB monolithic bundle into cacheable vendor chunks:

| Chunk | Size | Gzipped |
|---|---|---|
| `vendor-material` (@material-tailwind) | 654 kB | 142 kB |
| `vendor-core` (react + react-dom + router) | 341 kB | 108 kB |
| `vendor-konva` (konva + react-konva) | 285 kB | 85 kB |
| `vendor-ui` (react-select + lucide-react) | 88 kB | 31 kB |
| `index` (app code only) | **37 kB** | **13 kB** |

- Updated caniuse-lite to silence stale browserslist warning

## Test plan

- [ ] `yarn vitest run` — 68 tests pass
- [ ] `yarn build` — no warnings, five vendor chunks emitted
- [ ] Pan and zoom the map — no jank during zoom-out
- [ ] Pinch zoom on mobile — dots resize mid-gesture
- [ ] Mobile tooltip shows Owner, Damage, State correctly
- [ ] Pulse animation runs without restart glitch on event systems

🤖 Generated with [Claude Code](https://claude.com/claude-code)