### PR TITLE
fix: mobile zoom disappearance + restore missing env vars

### DIFF
--- a/src/components/hooks/useGalaxyViewport.ts
+++ b/src/components/hooks/useGalaxyViewport.ts
@@ -22,6 +22,19 @@ export function useGalaxyViewport({
     y: typeof window !== 'undefined' ? window.innerHeight / 2 : 0,
   });
 
+  // Synchronous scale-change listeners: called inside the same RAF as requestBatchDraw
+  // so group scales are always up-to-date before the canvas redraws.
+  const scaleListenersRef = useRef<Set<(scale: number) => void>>(new Set());
+
+  const registerScaleListener = useCallback((listener: (scale: number) => void) => {
+    scaleListenersRef.current.add(listener);
+    return () => { scaleListenersRef.current.delete(listener); };
+  }, []);
+
+  const notifyScaleListeners = useCallback((scale: number) => {
+    scaleListenersRef.current.forEach((fn) => fn(scale));
+  }, []);
+
   // Exposes current scale and position to React consumers that need rerenders.
   const [zoomScaleFactor, setZoomScaleFactor] = useState<number>(1);
   const [renderPosition, setRenderPosition] = useState<Point>(
@@ -91,6 +104,8 @@ export function useGalaxyViewport({
       stage.scale({ x: newScale, y: newScale });
       stage.position(positionRef.current);
 
+      // Update star-size compensation before the canvas redraws so there's no lag.
+      notifyScaleListeners(newScale);
       requestBatchDraw(stage);
       schedulePositionUpdate();
       setZoomScaleFactor(newScale);
@@ -132,6 +147,8 @@ export function useGalaxyViewport({
 
     requestBatchDraw,
     setZoomScaleFactor,
+    registerScaleListener,
+    notifyScaleListeners,
 
     handlers: {
       onWheel,

--- a/src/components/hooks/usePinchZoom.ts
+++ b/src/components/hooks/usePinchZoom.ts
@@ -11,6 +11,7 @@ type UsePinchZoomArgs = {
   // Shared from useGalaxyViewport so this hook can force a batched Konva redraw after math updates.
   requestBatchDraw: (stage: Konva.Stage) => void;
   setZoomScaleFactor: React.Dispatch<React.SetStateAction<number>>;
+  notifyScaleListeners: (scale: number) => void;
 
   hideTooltip?: () => void;
 
@@ -24,6 +25,7 @@ export function usePinchZoom({
   positionRef,
   requestBatchDraw,
   setZoomScaleFactor,
+  notifyScaleListeners,
   hideTooltip,
   minScale = 0.2,
   maxScale = 25,
@@ -126,6 +128,8 @@ export function usePinchZoom({
         stage.scale({ x: newScale, y: newScale });
         stage.position(newPos);
 
+        // Update star-size compensation before the canvas redraws so there's no lag.
+        notifyScaleListeners(newScale);
         requestBatchDraw(stage);
         setZoomScaleFactor(newScale);
 
@@ -136,6 +140,7 @@ export function usePinchZoom({
       isPinching,
       maxScale,
       minScale,
+      notifyScaleListeners,
       positionRef,
       requestBatchDraw,
       scaleRef,

--- a/src/components/pages/GalaxyMap.tsx
+++ b/src/components/pages/GalaxyMap.tsx
@@ -120,6 +120,8 @@ const GalaxyMapRender = ({
     view,
     requestBatchDraw,
     setZoomScaleFactor,
+    registerScaleListener,
+    notifyScaleListeners,
     handlers: { onWheel, onDragMove },
   } = useGalaxyViewport();
   const [searchTerm, setSearchTerm] = useState('');
@@ -144,6 +146,7 @@ const GalaxyMapRender = ({
     positionRef,
     requestBatchDraw,
     setZoomScaleFactor,
+    notifyScaleListeners,
     hideTooltip,
     minScale: MIN_SCALE,
     maxScale: MAX_SCALE,
@@ -351,6 +354,7 @@ const GalaxyMapRender = ({
           <StarSystem
             key={system.id}
             scaleRef={scaleRef}
+            registerScaleListener={registerScaleListener}
             system={system}
             factions={factions}
             settings={settings}
@@ -367,6 +371,7 @@ const GalaxyMapRender = ({
       factions,
       hideTooltip,
       normalizedSearch,
+      registerScaleListener,
       scaleRef,
       settings,
       shouldFilter,

--- a/src/components/ui/StarSystem.tsx
+++ b/src/components/ui/StarSystem.tsx
@@ -48,6 +48,7 @@ interface StarSystemProps {
   system: DisplayStarSystemType;
   factions: FactionDataType;
   scaleRef: React.RefObject<number>;
+  registerScaleListener: (listener: (scale: number) => void) => () => void;
   settings: Settings;
   showTooltip: (
     text: string,
@@ -68,6 +69,7 @@ interface StarSystemProps {
 const StarSystem: React.FC<StarSystemProps> = ({
   system,
   scaleRef,
+  registerScaleListener,
   factions,
   settings,
   showTooltip,
@@ -191,21 +193,13 @@ const StarSystem: React.FC<StarSystemProps> = ({
   // Keep the group scale in sync with the stage zoom imperatively so zoom events
   // don't trigger React re-renders for every visible StarSystem.
   useEffect(() => {
-    const group = groupRef.current;
-    if (!group) return;
-
-    let lastApplied = -1;
-
-    const animation = new Konva.Animation(() => {
-      const s = 1 / Math.min(scaleRef.current ?? 1, 1);
-      if (s === lastApplied) return false;
-      lastApplied = s;
+    return registerScaleListener((scale) => {
+      const group = groupRef.current;
+      if (!group) return;
+      const s = 1 / Math.min(scale, 1);
       group.scale({ x: s, y: s });
-    }, group.getLayer());
-
-    animation.start();
-    return () => { animation.stop(); };
-  }, [scaleRef]);
+    });
+  }, [registerScaleListener]);
 
   useEffect(() => {
     if (


### PR DESCRIPTION
## Summary

- **Mobile zoom fix**: zooming out on mobile caused all star dots to disappear. Root cause was a one-frame race between the per-star `Konva.Animation` loop and `requestBatchDraw` — at maximum zoom-out (stage scale 0.2) the group scale could be stale, making circles render at ~0.2 CSS pixels (invisible). Replaced 800 per-star animation loops with a single synchronous listener registry: scale listeners are called inside the same RAF as `requestBatchDraw`, so group scales are always applied before the canvas redraws.
- **Chunk splitting** (already in `system-state-nyx` via PR #44 — this PR adds only the mobile fix on top)

## Technical detail

`useGalaxyViewport` now exposes `registerScaleListener` / `notifyScaleListeners`. `usePinchZoom` and the wheel handler call `notifyScaleListeners` synchronously after writing `scaleRef.current`, before `requestBatchDraw`. Each `StarSystem` registers one callback that sets its Konva Group's compensating scale — zero RAF overhead when not zooming, and zero lag during zoom.

## Test plan

- [ ] Desktop wheel zoom: stars maintain constant screen size as expected
- [ ] Mobile pinch zoom out to minimum scale: stars remain visible (1 CSS px minimum)
- [ ] Mobile pinch zoom in: stars do not grow unexpectedly
- [ ] Insurrection / pirate-raid pulse animations still work after zoom
- [ ] Tooltip still appears on tap after zoom

🤖 Generated with [Claude Code](https://claude.com/claude-code)