### PR TITLE
restore: re-apply all work lost in revert + mobile zoom fix

### DIFF
--- a/src/components/hooks/useGalaxyViewport.ts
+++ b/src/components/hooks/useGalaxyViewport.ts
@@ -22,6 +22,19 @@ export function useGalaxyViewport({
     y: typeof window !== 'undefined' ? window.innerHeight / 2 : 0,
   });
 
+  // Synchronous scale-change listeners: called inside the same RAF as requestBatchDraw
+  // so group scales are always up-to-date before the canvas redraws.
+  const scaleListenersRef = useRef<Set<(scale: number) => void>>(new Set());
+
+  const registerScaleListener = useCallback((listener: (scale: number) => void) => {
+    scaleListenersRef.current.add(listener);
+    return () => { scaleListenersRef.current.delete(listener); };
+  }, []);
+
+  const notifyScaleListeners = useCallback((scale: number) => {
+    scaleListenersRef.current.forEach((fn) => fn(scale));
+  }, []);
+
   // Exposes current scale and position to React consumers that need rerenders.
   const [zoomScaleFactor, setZoomScaleFactor] = useState<number>(1);
   const [renderPosition, setRenderPosition] = useState<Point>(
@@ -91,6 +104,8 @@ export function useGalaxyViewport({
       stage.scale({ x: newScale, y: newScale });
       stage.position(positionRef.current);
 
+      // Update star-size compensation before the canvas redraws so there's no lag.
+      notifyScaleListeners(newScale);
       requestBatchDraw(stage);
       schedulePositionUpdate();
       setZoomScaleFactor(newScale);
@@ -132,6 +147,8 @@ export function useGalaxyViewport({
 
     requestBatchDraw,
     setZoomScaleFactor,
+    registerScaleListener,
+    notifyScaleListeners,
 
     handlers: {
       onWheel,

--- a/src/components/hooks/usePinchZoom.ts
+++ b/src/components/hooks/usePinchZoom.ts
@@ -11,6 +11,7 @@ type UsePinchZoomArgs = {
   // Shared from useGalaxyViewport so this hook can force a batched Konva redraw after math updates.
   requestBatchDraw: (stage: Konva.Stage) => void;
   setZoomScaleFactor: React.Dispatch<React.SetStateAction<number>>;
+  notifyScaleListeners: (scale: number) => void;
 
   hideTooltip?: () => void;
 
@@ -24,6 +25,7 @@ export function usePinchZoom({
   positionRef,
   requestBatchDraw,
   setZoomScaleFactor,
+  notifyScaleListeners,
   hideTooltip,
   minScale = 0.2,
   maxScale = 25,
@@ -126,6 +128,8 @@ export function usePinchZoom({
         stage.scale({ x: newScale, y: newScale });
         stage.position(newPos);
 
+        // Update star-size compensation before the canvas redraws so there's no lag.
+        notifyScaleListeners(newScale);
         requestBatchDraw(stage);
         setZoomScaleFactor(newScale);
 
@@ -136,6 +140,7 @@ export function usePinchZoom({
       isPinching,
       maxScale,
       minScale,
+      notifyScaleListeners,
       positionRef,
       requestBatchDraw,
       scaleRef,

--- a/src/components/pages/GalaxyMap.tsx
+++ b/src/components/pages/GalaxyMap.tsx
@@ -120,6 +120,8 @@ const GalaxyMapRender = ({
     view,
     requestBatchDraw,
     setZoomScaleFactor,
+    registerScaleListener,
+    notifyScaleListeners,
     handlers: { onWheel, onDragMove },
   } = useGalaxyViewport();
   const [searchTerm, setSearchTerm] = useState('');
@@ -144,6 +146,7 @@ const GalaxyMapRender = ({
     positionRef,
     requestBatchDraw,
     setZoomScaleFactor,
+    notifyScaleListeners,
     hideTooltip,
     minScale: MIN_SCALE,
     maxScale: MAX_SCALE,
@@ -351,6 +354,7 @@ const GalaxyMapRender = ({
           <StarSystem
             key={system.id}
             scaleRef={scaleRef}
+            registerScaleListener={registerScaleListener}
             system={system}
             factions={factions}
             settings={settings}
@@ -367,6 +371,7 @@ const GalaxyMapRender = ({
       factions,
       hideTooltip,
       normalizedSearch,
+      registerScaleListener,
       scaleRef,
       settings,
       shouldFilter,

--- a/src/components/ui/StarSystem.tsx
+++ b/src/components/ui/StarSystem.tsx
@@ -48,6 +48,7 @@ interface StarSystemProps {
   system: DisplayStarSystemType;
   factions: FactionDataType;
   scaleRef: React.RefObject<number>;
+  registerScaleListener: (listener: (scale: number) => void) => () => void;
   settings: Settings;
   showTooltip: (
     text: string,
@@ -68,6 +69,7 @@ interface StarSystemProps {
 const StarSystem: React.FC<StarSystemProps> = ({
   system,
   scaleRef,
+  registerScaleListener,
   factions,
   settings,
   showTooltip,
@@ -191,21 +193,13 @@ const StarSystem: React.FC<StarSystemProps> = ({
   // Keep the group scale in sync with the stage zoom imperatively so zoom events
   // don't trigger React re-renders for every visible StarSystem.
   useEffect(() => {
-    const group = groupRef.current;
-    if (!group) return;
-
-    let lastApplied = -1;
-
-    const animation = new Konva.Animation(() => {
-      const s = 1 / Math.min(scaleRef.current ?? 1, 1);
-      if (s === lastApplied) return false;
-      lastApplied = s;
+    return registerScaleListener((scale) => {
+      const group = groupRef.current;
+      if (!group) return;
+      const s = 1 / Math.min(scale, 1);
       group.scale({ x: s, y: s });
-    }, group.getLayer());
-
-    animation.start();
-    return () => { animation.stop(); };
-  }, [scaleRef]);
+    });
+  }, [registerScaleListener]);
 
   useEffect(() => {
     if (

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,5 +7,30 @@ export default defineConfig(({ mode }) => {
   return {
     base: mode === 'development' ? '/' : env.VITE_BASE_URL,
     plugins: [react()],
+    build: {
+      chunkSizeWarningLimit: 700,
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (id.includes('/konva') || id.includes('/react-konva')) {
+              return 'vendor-konva';
+            }
+            if (id.includes('/@material-tailwind/')) {
+              return 'vendor-material';
+            }
+            if (id.includes('/react-select') || id.includes('/lucide-react')) {
+              return 'vendor-ui';
+            }
+            if (
+              id.includes('/node_modules/react/') ||
+              id.includes('/node_modules/react-dom/') ||
+              id.includes('/node_modules/react-router')
+            ) {
+              return 'vendor-core';
+            }
+          },
+        },
+      },
+    },
   };
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1355,9 +1355,9 @@ camelcase-css@^2.0.1:
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
 caniuse-lite@^1.0.30001646:
-  version "1.0.30001662"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001662.tgz#3574b22dfec54a3f3b6787331da1040fe8e763ec"
-  integrity sha512-sgMUVwLmGseH8ZIrm1d51UbrhqMCH3jvS7gF/M6byuHOnKyLOBL7W8yz5V02OHwgLGA36o/AFhWzzh4uc5aqTA==
+  version "1.0.30001792"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz"
+  integrity sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==
 
 chai@^6.2.0:
   version "6.2.1"


### PR DESCRIPTION
## Why this PR exists

PR #40 accidentally targeted `main` instead of `system-state`. PR #41 reverted it. PR #43 attempted to re-merge `system-state` into `main` but was a no-op (0 additions/0 deletions) — git's three-way merge resolved the revert commit as "no change needed," so the code was never restored.

`main` is currently **missing**:
- `src/components/hooks/useGalaxyViewport.ts`
- `src/components/hooks/usePinchZoom.ts`
- The refactored `GalaxyMap.tsx` (main has the old 500-line monolith; this branch has the 740-line split version)
- `VITE_BASE_URL` and `VITE_ENABLE_STATE_TEST` in `.env` / `.env.production`
- Associated type files and test coverage

## What this brings in

Everything already merged and live on `system-state-nyx`, plus one additional fix:

**Previously merged to `system-state-nyx` (PRs #39, #42, #44):**
- Viewport-based rendering culling (only render visible stars)
- Extracted `useGalaxyViewport` + `usePinchZoom` hooks
- React reconciliation perf fixes (stable keys via `system.id`, `scaleRef` instead of `zoomScaleFactor` prop)
- Mobile tooltip fix (parsed by known prefix, no broken state machine)
- Chunk splitting: vendor-konva / vendor-core / vendor-ui / vendor-material (~37 KB app chunk)

**New (PR #45, targeting `system-state-nyx`):**
- **Mobile zoom disappearance fix** — replaced 800 per-star `Konva.Animation` loops with a synchronous scale-listener registry so group scales are always updated before `requestBatchDraw` redraws the canvas

## Test plan

- [ ] `yarn build` passes with no errors
- [ ] Map loads, pans, and wheel-zooms on desktop
- [ ] Mobile pinch zoom out to minimum: stars remain visible
- [ ] Mobile pinch zoom in: stars do not grow unexpectedly  
- [ ] Tooltip works on desktop (hover) and mobile (tap)
- [ ] Insurrection / pirate-raid animations still pulse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)