### PR TITLE
chore(dependabot): route updates to a 'dependabot-reqs' staging branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,11 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # Route updates to a staging branch so they can be tested before merging to main.
+    target-branch: "dependabot"
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    target-branch: "dependabot"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,10 @@ updates:
     schedule:
       interval: weekly
     # Route updates to a staging branch so they can be tested before merging to main.
-    target-branch: "dependabot"
+    target-branch: "dependabot-reqs"
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
-    target-branch: "dependabot"
+    target-branch: "dependabot-reqs"


### PR DESCRIPTION
## What
Adds `target-branch: "dependabot-reqs"` to both Dependabot update configs (npm + github-actions) so Dependabot opens its PRs against the `dependabot-reqs` staging branch instead of `main`.

## Why
Lets dependency bumps be tested on a staging branch before reaching `main`, instead of landing (or auto-merging) directly — guards against regressions like the Tailwind v3→v4 bump that blacked out the war map (CI didn't validate the built CSS). `dependabot-reqs` is used rather than `dependabot` to avoid colliding with the `dependabot/*` branch namespace Dependabot uses for its own PR branches.

## Status
The `dependabot-reqs` branch already exists, so this is ready to merge. Flow after merge: Dependabot → PRs into `dependabot-reqs` → test → merge `dependabot-reqs` → `main` (then re-sync `dependabot-reqs` with `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)